### PR TITLE
Only publish to NPM from /dist directory if prepack has been specified

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,8 +48,11 @@ jobs:
           cp README.md dist/README.md
           jq "del(.devDependencies) | del(.scripts) | del(.dependencies) | .main = \"index.js\"" package.json > dist/package.json
       
-      - run: |
+      - if: ${{ inputs.prepack }}
+        run: |
           cd dist
+
+      - run: |
           packageVersion="$(echo "${{ inputs.version }}" | sed 's/\(.*\)\./\1-/')"
           npm version $packageVersion
           npm publish --tag latest --access public


### PR DESCRIPTION
In [this commit](https://github.com/n3oltd/n3ojs/commit/ca2b5c6aa19a6577ececbf670c32d2f206c446ab) I updated the example Autocapitalize package with the assumption that when released to NPM it will not need to be built/bundled before release. Therefore there is no need for a /dist directory, no build step. The code inside [https://github.com/n3oltd/n3ojs/tree/master/src/auto-capitalize](https://github.com/n3oltd/n3ojs/tree/master/src/auto-capitalize) basically IS the bundle

In this NPM publish script, the only thing that needs changing is ensuring that if `prepack` is not `true`, we don't move into the `dist` directory and we can publish directly from the parent directory (auto-capitalize in the above example)

Not sure where the `prepack` gets set to `true`, can we change it to `false` for these n3o packages?