### PR TITLE
Update npm-publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,10 +48,10 @@ jobs:
           while [ -n "$dir" -a ! -f "$dir/LICENSE.md" ]; do
               dir=${dir%/*}
           done
-          if [ -f "$dir/LICENSE.md" ]; then cp "$dir/LICENSE.md" dist/LICENSE.md; fi
-          cp README.md dist/README.md
-          jq "del(.devDependencies) | del(.scripts) | del(.dependencies) | .main = \"index.js\"" package.json > dist/package.json
-          cd dist
+          if [ -f "$dir/LICENSE.md" ]; then cp "$dir/LICENSE.md" build/LICENSE.md; fi
+          cp README.md build/README.md
+          jq "del(.devDependencies) | del(.scripts) | del(.dependencies) | .main = \"index.js\"" package.json > build/package.json
+          cd build
           
       - run: |
           packageVersion="$(echo "${{ inputs.version }}" | sed 's/\(.*\)\./\1-/')"


### PR DESCRIPTION
Update script to publish from /build folder instead of /dist, because we use the same folder /build when running locally, which seems weird if it's called /dist.