### PR TITLE
Publish NPM and NUget packages to Azure feed

### DIFF
--- a/.github/actions/dotnet-push/action.yml
+++ b/.github/actions/dotnet-push/action.yml
@@ -23,3 +23,14 @@ runs:
           echo "Project: $project"
           (cd $project; dotnet nuget push **/*.nupkg -k ${{inputs.access-token}} --source "https://nuget.pkg.github.com/n3oltd/index.json" --skip-duplicate)
         done
+
+    - name: Push Nuget packages to Azure Artifacts
+      shell: bash
+      working-directory: ${{github.workspace}}/src
+      run: |
+        listOfProjects=$(echo '${{ inputs.projects }}' | jq -c -r '.[]')        
+        for project in $listOfProjects
+        do
+          echo "Pushing project: $project"          
+          (cd $project; dotnet nuget push **/*.nupkg --skip-duplicate --api-key az --source n3o )          
+        done   

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -39,7 +39,7 @@ runs:
             echo "//pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/:username=n3oltd" >> .npmrc;
             echo "//pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/:_password=${{ inputs.azure-feed-token }}" >> .npmrc;
             echo "//pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/:email=n3oltd@n3oltd.com" >> .npmrc; 
-            echo "@aminjafer-n3o:registry=https://pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/registry/" >> .npmrc;
+            echo "n3oltd:registry=https://pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/registry/" >> .npmrc;
             cat .npmrc; ls -a; npm publish )
         done
       working-directory: ${{github.workspace}}

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -25,3 +25,21 @@ runs:
       working-directory: ${{github.workspace}}
       env: 
         NODE_AUTH_TOKEN: ${{inputs.access-token}}
+        
+    - name: Npm publish to Azure feed
+      shell: bash
+      run: |
+        listOfDirectories=$(echo '${{ inputs.client-directories }}' | jq -c -r '.[]')                
+        for packageDirectory in $listOfDirectories        
+        do          
+          ( cd $packageDirectory; rm .npmrc; 
+            echo "//pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/registry/:username=a2658dbf-ef4b-4609-9d8d-9c65c96f86a4" >> .npmrc;
+            echo "//pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/registry/:_password=${{ inputs.azure-feed-token }}" >> .npmrc;
+            echo "//pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/registry/:email=n3oltd@n3oltd.com" >> .npmrc;
+            echo "//pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/:username=n3oltd" >> .npmrc;
+            echo "//pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/:_password=${{ inputs.azure-feed-token }}" >> .npmrc;
+            echo "//pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/:email=n3oltd@n3oltd.com" >> .npmrc; 
+            echo "@aminjafer-n3o:registry=https://pkgs.dev.azure.com/n3oltd/_packaging/Feed/npm/registry/" >> .npmrc;
+            cat .npmrc; ls -a; npm publish )
+        done
+      working-directory: ${{github.workspace}}

--- a/.github/workflows/karakoram/dotnet-build-pack-push.yml
+++ b/.github/workflows/karakoram/dotnet-build-pack-push.yml
@@ -23,11 +23,6 @@ on:
         required: true
         type: string
 
-    secrets:
-      access-token:
-        description: A valid PAT with suitable permissions
-        required: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -65,11 +60,12 @@ jobs:
         uses: n3o/actions/.github/actions/dotnet-push@main
         with:
           projects: ${{ inputs.nuget-packages }}
-          access-token: ${{ secrets.access-token }}
+          access-token: ${{ secrets.GH_PACKAGES_TOKEN }}
 
       - name: npm publish clients packages
         if: inputs.npm-packages != ''
         uses: n3o/actions/.github/actions/npm-publish@main
         with:
           package-directories: ${{ inputs.npm-packages }}
-          access-token: ${{ secrets.access-token }} 
+          access-token: ${{ secrets.GH_PACKAGES_TOKEN }}
+          azure-feed-token: ${{ secrets.AZURE_FEED_CREDENTIALS }} 


### PR DESCRIPTION
Changes to publish the nuget and NPM package to Azure feed also. Passign secrets to the reusable workflow using 'inherit' option. This way the called workflow can simply access the secrets available to the calling workflow with having to explicitly pass them. 