### PR TITLE
Added a dotnet-build-only yaml file 

### DIFF
--- a/.github/workflows/karakoram/dotnet-build-only.yml
+++ b/.github/workflows/karakoram/dotnet-build-only.yml
@@ -1,0 +1,20 @@
+﻿name: dotnet build only workflow
+
+on:
+  workflow_call:
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup-dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '7.x'
+
+      - name: dotnet build
+        uses: n3o/actions/.github/actions/dotnet-build@main


### PR DESCRIPTION
The build only file is called from main-pr.yml so that we have a central place to make any future changes if required. 