### PR TITLE
build: drop unused PUBLIC_URL build-arg from n3o-react Dockerfile

### DIFF
--- a/docker/n3o-react
+++ b/docker/n3o-react
@@ -15,10 +15,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 ARG REACT_APP_SENTRY_RELEASE
-ARG PUBLIC_URL
 
 ENV REACT_APP_SENTRY_RELEASE=${REACT_APP_SENTRY_RELEASE} \
-    PUBLIC_URL=${PUBLIC_URL} \
     NODE_OPTIONS=--max-old-space-size=4096
 
 COPY package.json package-lock.json .npmrc ./


### PR DESCRIPTION
fe-engage is the only consumer of the `n3o-react` Dockerfile and is moving its base path config from build-time (`PUBLIC_URL` webpack bake) to runtime (`__webpack_public_path__` set from `window.__APP_ENV__` at startup). The `ARG PUBLIC_URL` and matching ENV line in this Dockerfile are now dead — remove them.

Confirmed via `grep -rln "PUBLIC_URL=" --include="*.yml"` across `/Users/noor/Source/` that fe-engage is the sole consumer.

Refs n3oltd/devops#106