### PR TITLE
build: inject dated APP_VERSION build-arg; bump npm version in n3o-react Dockerfile

### DIFF
--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -84,6 +84,7 @@ jobs:
           VERSIONTAG="${ACR_REPOSITORY}:${VERSION}"
           LATESTTAG="${ACR_REPOSITORY}:latest"
           CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "version-tag=$VERSIONTAG" >> $GITHUB_OUTPUT
           echo "latest-tag=$LATESTTAG" >> $GITHUB_OUTPUT
           echo "created=$CREATED" >> $GITHUB_OUTPUT
@@ -96,6 +97,7 @@ jobs:
             echo "args<<EOF"
             echo "FEED_URL=https://nuget.pkg.github.com/n3oltd/index.json"
             echo "PAT=${{ env.GH_PAT }}"
+            echo "APP_VERSION=${{ steps.metadata.outputs.version }}"
             if [[ -n "${{ secrets.PRINCE_LICENSE_ID }}" ]]; then
               echo "PRINCE_LICENSE_ID=${{ secrets.PRINCE_LICENSE_ID }}"
               echo "PRINCE_LICENSE_NAME=${{ secrets.PRINCE_LICENSE_NAME }}"

--- a/docker/n3o-react
+++ b/docker/n3o-react
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 ARG REACT_APP_SENTRY_RELEASE
+ARG APP_VERSION
 
 ENV REACT_APP_SENTRY_RELEASE=${REACT_APP_SENTRY_RELEASE} \
     NODE_OPTIONS=--max-old-space-size=4096
@@ -26,6 +27,11 @@ RUN --mount=type=secret,id=github_token,required=true \
     npm ci
 
 COPY . .
+
+# Align package.json version with image tag so build logs / Sentry / runtime show the deployed version.
+RUN if [ -n "$APP_VERSION" ]; then \
+      npm version "$APP_VERSION" --no-git-tag-version --allow-same-version; \
+    fi
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
The reusable workflow already computes `VERSION` (`$YYYY.M.D.run_number`) for the image tag but didn't expose it to Dockerfiles. Karakoram .NET services have a dated version in build output / assembly metadata; fe-engage's npm log stays at the static `1.0.0` from package.json, making it impossible to tell which build is running from a runtime log.

## Changes

1. **`n3o-docker-build-push.yml`** — expose the bare `VERSION` as a step output and pass it as a Docker build-arg `APP_VERSION`. Two lines.

2. **`docker/n3o-react`** — declare `ARG APP_VERSION`, then between `npm ci` and `npm run build`:
   ```dockerfile
   RUN if [ -n "$APP_VERSION" ]; then \
         npm version "$APP_VERSION" --no-git-tag-version --allow-same-version; \
       fi
   ```
   `--no-git-tag-version` skips creating a git tag/commit (there's no git in the container); `--allow-same-version` is a safety net for re-runs.

## Effect

Next fe-engage build will log `> @n3oltd/fe-engage@2026.5.17.NN build /app` instead of `> @n3oltd/fe-engage@1.0.0 build /app`. The version also surfaces in `process.env.npm_package_version` at build time and in runtime probes that read package.json.

## Backwards compatibility

The new build-arg is harmless for Dockerfiles that don't declare it — Docker just warns about an unused arg. Existing `n3o-dotnet` and other consumers unaffected.

Refs n3oltd/devops#106