### PR TITLE
publish-karakoram-content: split image-assets upload to 'karakoram' container

### DIFF
--- a/.github/workflows/publish-karakoram-content.yml
+++ b/.github/workflows/publish-karakoram-content.yml
@@ -43,10 +43,8 @@ jobs:
           yml_to_json karakoram/welcome-info     _publish/karakoram/welcomeInfo
           yml_to_json karakoram/featured-content _publish/karakoram/featuredContent
           yml_to_json karakoram/getting-started  _publish/karakoram/gettingStarted
-          yml_to_json karakoram/image-assets     _publish/karakoram/imageAssets
 
           copy_dir karakoram/getting-started/images _publish/karakoram/gettingStarted/images
-          copy_dir karakoram/image-assets/files     _publish/karakoram/imageAssets/files
 
       - name: Azure Login
         uses: azure/login@v3
@@ -67,4 +65,20 @@ jobs:
             --destination global \
             --destination-path karakoram \
             --source _publish/karakoram \
+            --overwrite
+
+      - name: Replace assets/ in karakoram container
+        run: |
+          az storage blob delete-batch \
+            --account-name n3oltd \
+            --auth-mode login \
+            --source karakoram \
+            --pattern 'assets/*'
+
+          az storage blob upload-batch \
+            --account-name n3oltd \
+            --auth-mode login \
+            --destination karakoram \
+            --destination-path assets \
+            --source karakoram/image-assets \
             --overwrite


### PR DESCRIPTION
## Summary
Splits the image-assets upload out of the `global` container (which serves authenticated `IGlobalBlobs` reads) and into a new dedicated public `karakoram` container, matching the URL contract K2.DataImport now emits (`cdn.n3o.cloud/karakoram/assets/<file>.png`).

## Changes
- Drops the `yml_to_json` + `copy_dir` lines for image-assets out of the `_publish/karakoram` tree (it doesn't ship to `global` anymore).
- Adds a new `Replace assets/ in karakoram container` step that uploads `n3oltd/devops karakoram/image-assets/` to the `karakoram` container under `assets/`.

The other content (release-notes / welcome-info / featured-content / getting-started) keeps shipping to `global/karakoram/*` as before — that's authenticated server-side content read by `IGlobalBlobs`, not browser-facing.

## Companion PRs
- `n3oltd/devops#146` — file renames + flattened layout + index.yml removal.
- `Karakoram.DataImport` (next) — `TemplateFactory.cs:.Image("give-wp")` → `.Image("givewp")` so the URL matches the renamed file.
- `Karakoram.Donations` + `Karakoram.Pledges` (next) — lowercase the 6 `.Image(...)` brand-id sites.

## Infra already in place
- `karakoram` container created on `n3oltd` storage with `--public-access blob`.
- `cdn.n3o.cloud/karakoram/*` verified to route through Front Door to the storage account (confirmed by `x-azure-ref` header on 404 probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)