### PR TITLE
publish-karakoram-content: fan-out assets upload to all 3 env storages

### DIFF
--- a/.github/workflows/publish-karakoram-content.yml
+++ b/.github/workflows/publish-karakoram-content.yml
@@ -67,18 +67,22 @@ jobs:
             --source _publish/karakoram \
             --overwrite
 
-      - name: Replace assets/ in karakoram container
+      - name: Replace assets/ in karakoram container (all envs)
         run: |
-          az storage blob delete-batch \
-            --account-name n3oltd \
-            --auth-mode login \
-            --source karakoram \
-            --pattern 'assets/*'
+          for account in eu1storageprod eu1storageqa eu1storagestaging; do
+            echo "::group::$account"
+            az storage blob delete-batch \
+              --account-name "$account" \
+              --auth-mode login \
+              --source karakoram \
+              --pattern 'assets/*'
 
-          az storage blob upload-batch \
-            --account-name n3oltd \
-            --auth-mode login \
-            --destination karakoram \
-            --destination-path assets \
-            --source karakoram/image-assets \
-            --overwrite
+            az storage blob upload-batch \
+              --account-name "$account" \
+              --auth-mode login \
+              --destination karakoram \
+              --destination-path assets \
+              --source karakoram/image-assets \
+              --overwrite
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## Summary
Fixes the storage account misroute from #60. `cdn.n3o.cloud` and its beta/staging siblings are each fronted by their own per-env storage account — verified via the `n3o-cloud` AFD profile:

| Host | Endpoint | Storage origin |
|---|---|---|
| `cdn.n3o.cloud` | `n3oltd-static` | `eu1storageprod` |
| `cdn-beta.n3o.cloud` | `n3oltd-beta-static` | `eu1storageqa` |
| `cdn-staging.n3o.cloud` | `n3oltd-staging-static` | `eu1storagestaging` |

Beta/staging deploys emit URLs against their own CDN host (`StaticFilesDomain` is env-driven), so the cross-tenant image-assets need to live in all three storage accounts for every env's CDN host to resolve.

## Change
The new "Replace assets/ in karakoram container" step now loops over the three account names. Same `delete-batch` + `upload-batch` as before, done thrice. Storage cost is trivial (34 PNGs × 3 envs, few MB).

The existing "Replace karakoram/ in global container" step is unchanged — still targets `n3oltd` only, since `IGlobalBlobs` reads that with auth.

## Why not framework-side `Host` override
Considered: have `CdnRoots.KarakoramAssets` always emit `cdn.n3o.cloud` regardless of env. Rejected because it introduces a new exception ("most CdnRoots are env-aware, but this one isn't") into a framework whose existing pattern is *each env owns its own storage*. The fan-out preserves that pattern without adding any framework concept, and avoids cross-env runtime coupling (beta deploys depending on prod CDN being up).

## Infra already in place
- `karakoram` container created with `--public-access blob` on all three storage accounts (`eu1storageprod`, `eu1storageqa`, `eu1storagestaging`).
- AFD routes `/*` on each `*-static` endpoint already forward every path to that env's storage; nothing extra needed.

## Cleanup
- Orphan `karakoram` container on `n3oltd` (created in error earlier) can be deleted — harmless meanwhile.

## Test plan
- [ ] Merge + manually trigger `publish-karakoram-content.yml` on `n3oltd/devops`
- [ ] `curl -I https://cdn.n3o.cloud/karakoram/assets/amanahfy.png` → 200
- [ ] `curl -I https://cdn-beta.n3o.cloud/karakoram/assets/amanahfy.png` → 200
- [ ] `curl -I https://cdn-staging.n3o.cloud/karakoram/assets/amanahfy.png` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)