### PR TITLE
publish-karakoram-content: drop staging from karakoram-assets fan-out

### DIFF
--- a/.github/workflows/publish-karakoram-content.yml
+++ b/.github/workflows/publish-karakoram-content.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Replace assets/ in karakoram container (all envs)
         run: |
-          for account in eu1storageprod eu1storageqa eu1storagestaging; do
+          for account in eu1storageprod eu1storageqa; do
             echo "::group::$account"
             az storage blob delete-batch \
               --account-name "$account" \


### PR DESCRIPTION
## Summary
Tightens the loop introduced in #61 to **prod + qa only**. karakoram-assets aren't hosted on the staging env per direction.

\`\`\`diff
- for account in eu1storageprod eu1storageqa eu1storagestaging; do
+ for account in eu1storageprod eu1storageqa; do
\`\`\`

## Notes
- Permissions verified: the workflow's service principal has `Storage Blob Data Contributor` on both `eu1storageprod` and `eu1storageqa` (granted ahead of this PR).
- `karakoram` container on `eu1storagestaging` was created earlier but stays empty — harmless. Can delete at leisure.
- The previous run (workflow id 26438660014) failed because the SP didn't yet have the role on the `eu1storage*` accounts; granting it + this trim should make the next run pass.

## Test plan
- [ ] Merge + manually trigger `publish-karakoram-content.yml` on `n3oltd/devops`
- [ ] `curl -I https://cdn.n3o.cloud/karakoram/assets/amanahfy.png` → 200
- [ ] `curl -I https://cdn-beta.n3o.cloud/karakoram/assets/amanahfy.png` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)