### PR TITLE
Add Sentry release wiring to shared build + deploy workflows

### DIFF
--- a/.github/actions/n3o-sentry-release/action.yml
+++ b/.github/actions/n3o-sentry-release/action.yml
@@ -1,0 +1,41 @@
+name: 'N3O Sentry release'
+description: |-
+  Creates a Sentry release (and optional deploy event / source map upload) for
+  the calling workflow. Wraps getsentry/action-release with our org defaults
+  baked in so callers only pass what varies per project.
+
+inputs:
+  project:
+    required: true
+  release:
+    required: true
+  environment:
+    required: false
+    default: ''
+  sourcemaps:
+    required: false
+    default: ''
+  auth-token:
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Sentry release
+      uses: getsentry/action-release@v3
+      env:
+        SENTRY_ORG: n3oltd
+        SENTRY_PROJECT: ${{ inputs.project }}
+        SENTRY_AUTH_TOKEN: ${{ inputs.auth-token }}
+      with:
+        release: ${{ inputs.release }}
+        environment: ${{ inputs.environment }}
+        sourcemaps: ${{ inputs.sourcemaps }}
+        # At build time (no environment), the runner is in the source repo,
+        # so set_commits=auto walks its git log and registers the repo entry.
+        # At deploy time, the runner is in the deployments repo — auto would
+        # attribute the wrong commits, so skip.
+        set_commits: ${{ inputs.environment == '' && 'auto' || 'skip' }}
+        ignore_missing: true
+        ignore_empty: true
+        disable_telemetry: true

--- a/.github/actions/n3o-sentry-release/action.yml
+++ b/.github/actions/n3o-sentry-release/action.yml
@@ -1,8 +1,4 @@
 name: 'N3O Sentry release'
-description: |-
-  Creates a Sentry release (and optional deploy event / source map upload) for
-  the calling workflow. Wraps getsentry/action-release with our org defaults
-  baked in so callers only pass what varies per project.
 
 inputs:
   project:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -19,12 +19,25 @@ on:
         type: string
         default: src
 
+      sentry-project:
+        type: string
+        required: false
+        default: ''
+
+      sentry-sourcemaps:
+        type: string
+        required: false
+        default: ''
+
     secrets:
       acr-username:
         required: true
 
       acr-password:
         required: true
+
+      sentry-auth-token:
+        required: false
 
 jobs:
   job1:
@@ -75,3 +88,12 @@ jobs:
             SOURCE_REVISION_ID=${{ github.sha }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+
+      - name: sentry release
+        if: inputs.sentry-project != ''
+        uses: n3oltd/actions/.github/actions/n3o-sentry-release@main
+        with:
+          project: ${{ inputs.sentry-project }}
+          release: ${{ steps.meta.outputs.version }}
+          sourcemaps: ${{ inputs.sentry-sourcemaps }}
+          auth-token: ${{ secrets.sentry-auth-token }}

--- a/.github/workflows/n3o-aks-deployment.yml
+++ b/.github/workflows/n3o-aks-deployment.yml
@@ -15,6 +15,16 @@ on:
         type: string
         required: true
 
+      sentry-project:
+        type: string
+        required: false
+        default: ''
+
+      sentry-environment:
+        type: string
+        required: false
+        default: ''
+
 jobs:
   deploy-to-aks:
     name: Deploy service to AKS
@@ -46,3 +56,12 @@ jobs:
         with:
           namespace: ${{ inputs.namespace }}
           working-directory: ${{ inputs.deployment-folder }}/${{ steps.latest-json-metadata.outputs.deploymentVersion }}
+
+      - name: sentry deploy
+        if: inputs.sentry-project != ''
+        uses: n3oltd/actions/.github/actions/n3o-sentry-release@main
+        with:
+          project: ${{ inputs.sentry-project }}
+          release: ${{ steps.latest-json-metadata.outputs.deploymentVersion }}
+          environment: ${{ inputs.sentry-environment }}
+          auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -31,6 +31,16 @@ on:
         required: false
         default: ''
 
+      sentry-project:
+        type: string
+        required: false
+        default: ''
+
+      sentry-sourcemaps:
+        type: string
+        required: false
+        default: ''
+
 env:
   GH_PAT: ${{ secrets.GH_PAT }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -84,6 +94,7 @@ jobs:
           VERSIONTAG="${ACR_REPOSITORY}:${VERSION}"
           LATESTTAG="${ACR_REPOSITORY}:latest"
           CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "version-tag=$VERSIONTAG" >> $GITHUB_OUTPUT
           echo "latest-tag=$LATESTTAG" >> $GITHUB_OUTPUT
           echo "created=$CREATED" >> $GITHUB_OUTPUT
@@ -136,3 +147,12 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: sentry release
+        if: steps.check-existing.outputs.exists != 'true' && inputs.sentry-project != ''
+        uses: n3oltd/actions/.github/actions/n3o-sentry-release@main
+        with:
+          project: ${{ inputs.sentry-project }}
+          release: ${{ steps.metadata.outputs.version }}
+          sourcemaps: ${{ inputs.sentry-sourcemaps }}
+          auth-token: ${{ env.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/n3o-sites-deploy.yml
+++ b/.github/workflows/n3o-sites-deploy.yml
@@ -11,6 +11,16 @@ on:
         type: string
         required: true
 
+      sentry-project:
+        type: string
+        required: false
+        default: ''
+
+      sentry-environment:
+        type: string
+        required: false
+        default: ''
+
 jobs:
   deploy-to-aks:
     name: Deploy to AKS
@@ -42,3 +52,12 @@ jobs:
         with:
           working-directory: ${{ inputs.data-region }}/sites/${{ inputs.site-id }}/${{ steps.get-deployment-version.outputs.deploymentVersion }}
           replace-yaml: false
+
+      - name: sentry deploy
+        if: inputs.sentry-project != ''
+        uses: n3oltd/actions/.github/actions/n3o-sentry-release@main
+        with:
+          project: ${{ inputs.sentry-project }}
+          release: ${{ steps.get-deployment-version.outputs.deploymentVersion }}
+          environment: ${{ inputs.sentry-environment }}
+          auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Phase 1 of adding Sentry releases across the org. Wires an **optional** `sentry-project` input into 4 shared workflows; nothing changes for consumers that don't opt in, but those that do get a Sentry release per build and deploy events per deployment.

### What lands here

- **`n3o-sentry-release` composite action** (`.github/actions/n3o-sentry-release/`) — thin wrapper around `getsentry/action-release@v3` with our defaults baked in: `SENTRY_ORG=n3oltd`, `ignore_missing/empty=true`, `disable_telemetry=true`. Auto-switches `set_commits` between `auto` (build time, runner in source repo) and `skip` (deploy time, runner in `deployments` repo and the release already has commits from the build).

- **Build workflows**: new optional `sentry-project` + `sentry-sourcemaps` inputs on:
  - `n3o-docker-build-push.yml` — backends + engage
  - `docker-build-push.yml` — sites
  
  When set, a Sentry release is created using the existing date-based version tag (e.g. `2026.5.22.1265`) as the release id, commits are attached, and (as a side effect of `set_commits`) the repo entry is registered in Sentry.

- **Deploy workflows**: new optional `sentry-project` + `sentry-environment` inputs on:
  - `n3o-aks-deployment.yml` — backend deploys
  - `n3o-sites-deploy.yml` — site deploys
  
  When set, a deploy event is attached to the existing release (read from the deployment's `metadata.json` deploymentVersion, which is the same version tag the build used).

### What doesn't change

Zero behaviour change for any consumer that doesn't pass `sentry-project`. All gated on `if: inputs.sentry-project != ''`.

### Release id

The existing date version-tag (e.g. `2026.5.22.1265`) used as the Sentry release id throughout. Build computes it; deploy reads it from `metadata.json`. They line up automatically.

### Test plan

- [ ] Merge this and confirm CI on a no-opt-in repo (e.g. svc-be-cart) is unchanged.
- [ ] Phase 2 (separate PR): wire one consumer — svc-be-accounts/build-container.yml — to pass `sentry-project: backend`. Trigger a build and verify the release shows up in Sentry's `backend` project with commits attached.
- [ ] Confirm the repo entry for `svc-be-accounts` is created in Sentry's repo registry as a side-effect.
- [ ] Phase 2 onward: bulk rollout per repo, then sites + frontend + deploys.