### PR TITLE
dotnet-build-pack-push: optional Sentry release on pack

### DIFF
--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -41,9 +41,17 @@ on:
         type: string
         default: ''
 
+      sentry-project:
+        type: string
+        required: false
+        default: ''
+
     secrets:
       nuget-api-key:
         required: false
+
+env:
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 jobs:
   job1:
@@ -101,3 +109,11 @@ jobs:
       - name: dotnet nuget push
         if: ${{ inputs.run-pack }}
         run: dotnet nuget push "**/*.nupkg" --source "${{ inputs.nuget-source }}" --api-key "${{ secrets.nuget-api-key }}" --skip-duplicate --timeout 900
+
+      - name: sentry release
+        if: inputs.sentry-project != ''
+        uses: n3oltd/actions/.github/actions/n3o-sentry-release@main
+        with:
+          project: ${{ inputs.sentry-project }}
+          release: ${{ github.event.repository.name }}@${{ steps.prepare.outputs.VERSION }}
+          auth-token: ${{ env.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Extends the shared `dotnet-build-pack-push.yml` workflow with an optional `sentry-project` input. When set, the workflow creates a Sentry release after the nuget push, using the existing `n3o-sentry-release` composite (which wraps `getsentry/action-release@v3`).

## Release id

`${{ github.event.repository.name }}@${{ VERSION }}` — e.g. `umbraco-extensions@2026.5.31.5`. Namespacing by repo name keeps library releases distinct from the bare-version releases the docker workflows create (e.g. `2026.5.31.651` for svc-be-accounting).

## Effect

- Zero behaviour change for the 130+ `lib-be-*` repos that call this workflow without `sentry-project`.
- Unblocks wiring umbraco-extensions' main-ci to register Sentry releases (separate PR in that repo).

## Test plan

- [ ] Merge.
- [ ] Pilot via umbraco-extensions main-ci PR: trigger a build, confirm a release `umbraco-extensions@<version>` appears in the `sites` Sentry project with commits attached, and that the `n3oltd/umbraco-extensions` repo entry is registered.