### PR TITLE
dotnet-build-pack-push: optional caller-supplied version

### DIFF
--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -33,6 +33,13 @@ on:
         # 'tag': version from git tag (refs/tags/v*), fallback 1.0.0
         # 'date': date-based version (YYYY.M.D.run_number)
 
+      version:
+        type: string
+        default: ''
+        # If set, takes precedence over version-strategy. Use when the caller
+        # has already computed the version (e.g. scheduled releases triggered
+        # from a branch rather than a tag).
+
       nuget-source:
         type: string
         default: 'https://api.nuget.org/v3/index.json'
@@ -73,7 +80,9 @@ jobs:
       - id: prepare
         name: Set version
         run: |
-          if [ "${{ inputs.version-strategy }}" = "date" ]; then
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          elif [ "${{ inputs.version-strategy }}" = "date" ]; then
             NOW=$(date +'%Y.%-m.%-d')
             VERSION="$NOW.${{ github.run_number }}"
           else


### PR DESCRIPTION
## Summary
- Adds an optional `version` input to `dotnet-build-pack-push.yml` that, when set, takes precedence over `version-strategy`.
- Unblocks callers that compute the version themselves — e.g. a scheduled workflow that cuts a tag from a branch rather than being triggered by a `refs/tags/v*` push.

## Why
The reusable workflow currently derives the version from `\$GITHUB_REF` (the `tag` strategy) or from the run date (`date` strategy). When triggered from a branch (e.g. `schedule` or `workflow_dispatch`) under the `tag` strategy it falls back to `1.0.0`. Letting the caller supply a version directly is the smallest fix and keeps existing callers unchanged.

## Test plan
- [ ] Existing callers using `version-strategy: tag` on tag push continue to derive the version from the tag (no `version` input passed).
- [ ] Existing caller using `version-strategy: date` (umbraco-extensions main-ci) continues to use date-based versions.
- [ ] New caller in umbraco-extensions tag-ci passes `version: 13.0.x` and the dotnet pack uses exactly that.

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)