### PR TITLE
Sentry: extract sourcemaps from container; wire platforms-js release

### DIFF
--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -36,10 +36,10 @@ on:
         required: false
         default: ''
 
-      sentry-sourcemaps:
-        type: string
+      sentry-extract-sourcemaps:
+        type: boolean
         required: false
-        default: ''
+        default: false
 
 env:
   GH_PAT: ${{ secrets.GH_PAT }}
@@ -148,11 +148,26 @@ jobs:
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
+      - name: extract sourcemaps
+        if: steps.check-existing.outputs.exists != 'true' && inputs.sentry-project != '' && inputs.sentry-extract-sourcemaps
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          target: sourcemaps
+          outputs: type=local,dest=${{ runner.temp }}/sourcemaps
+          build-args: ${{ steps.build-args.outputs.args }}
+          secrets: |
+            github_token=${{ env.GH_PAT }}
+            sentry_auth_token=${{ env.SENTRY_AUTH_TOKEN }}
+            ${{ inputs.secrets }}
+
       - name: sentry release
         if: steps.check-existing.outputs.exists != 'true' && inputs.sentry-project != ''
         uses: n3oltd/actions/.github/actions/n3o-sentry-release@main
         with:
           project: ${{ inputs.sentry-project }}
           release: ${{ steps.metadata.outputs.version }}
-          sourcemaps: ${{ inputs.sentry-sourcemaps }}
+          sourcemaps: ${{ inputs.sentry-extract-sourcemaps && format('{0}/sourcemaps', runner.temp) || '' }}
           auth-token: ${{ env.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -107,6 +107,13 @@ jobs:
             echo "args<<EOF"
             echo "FEED_URL=https://nuget.pkg.github.com/n3oltd/index.json"
             echo "PAT=${{ env.GH_PAT }}"
+            if [[ -n "${{ inputs.sentry-project }}" ]]; then
+              # Bake the Sentry release id (date version-tag) into common
+              # frontend env-var names so the runtime SDK tags events with
+              # the same release id the composite creates.
+              echo "REACT_APP_SENTRY_RELEASE=${{ steps.metadata.outputs.version }}"
+              echo "VITE_SENTRY_RELEASE=${{ steps.metadata.outputs.version }}"
+            fi
             if [[ -n "${{ secrets.PRINCE_LICENSE_ID }}" ]]; then
               echo "PRINCE_LICENSE_ID=${{ secrets.PRINCE_LICENSE_ID }}"
               echo "PRINCE_LICENSE_NAME=${{ secrets.PRINCE_LICENSE_NAME }}"

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -108,9 +108,6 @@ jobs:
             echo "FEED_URL=https://nuget.pkg.github.com/n3oltd/index.json"
             echo "PAT=${{ env.GH_PAT }}"
             if [[ -n "${{ inputs.sentry-project }}" ]]; then
-              # Bake the Sentry release id (date version-tag) into common
-              # frontend env-var names so the runtime SDK tags events with
-              # the same release id the composite creates.
               echo "REACT_APP_SENTRY_RELEASE=${{ steps.metadata.outputs.version }}"
               echo "VITE_SENTRY_RELEASE=${{ steps.metadata.outputs.version }}"
             fi

--- a/.github/workflows/n3o-platforms-js-build-push.yml
+++ b/.github/workflows/n3o-platforms-js-build-push.yml
@@ -7,8 +7,14 @@ on:
         type: string
         required: true
 
+      sentry-project:
+        type: string
+        required: false
+        default: ''
+
 env:
   GH_PAT: ${{ secrets.GH_PAT }}
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 jobs:
   build-push:
@@ -56,13 +62,27 @@ jobs:
           npm_config_fetch_retry_mintimeout: 30000
           npm_config_fetch_retries: 5
 
+      - id: version
+        name: compute version
+        run: |
+          version="$(date +"%Y.%m.%d")-${{ github.run_number }}"
+          echo "version=$version" >> $GITHUB_OUTPUT
+
       - name: npm publish
         working-directory: packages/n3o-elements
         run: |
-          version=$(date +"%Y.%m.%d")-${{ github.run_number }}
           name="@n3oltd/platforms-js-${{ inputs.subscription-code }}"
           jq "del(.devDependencies, .scripts, .dependencies) | .name = \"$name\"" package.json > tmp.json && mv tmp.json package.json
-          npm version $version;
+          npm version ${{ steps.version.outputs.version }};
           echo "//npm.pkg.github.com/:_authToken=${{ env.GH_PAT }}" >> .npmrc;
           echo "@n3oltd:registry=https://npm.pkg.github.com" >> .npmrc;
           npm publish;
+
+      - name: sentry release
+        if: inputs.sentry-project != ''
+        uses: n3oltd/actions/.github/actions/n3o-sentry-release@main
+        with:
+          project: ${{ inputs.sentry-project }}
+          release: platforms-js@${{ steps.version.outputs.version }}-${{ inputs.subscription-code }}
+          sourcemaps: packages/n3o-elements/dist
+          auth-token: ${{ env.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/n3o-platforms-js-build-push.yml
+++ b/.github/workflows/n3o-platforms-js-build-push.yml
@@ -52,6 +52,14 @@ jobs:
             '{localization: ($localization | fromjson)}' \
             > packages/formatter/src/configuration.json
 
+      - id: version
+        name: compute version
+        run: |
+          version="$(date +"%Y.%m.%d")-${{ github.run_number }}"
+          echo "version=$version" >> $GITHUB_OUTPUT
+          release="platforms-js@$version-${{ inputs.subscription-code }}"
+          echo "release=$release" >> $GITHUB_OUTPUT
+
       - name: npm install and build
         run: |
           npm ci --legacy-peer-deps
@@ -59,14 +67,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ env.GH_PAT }}
           VITE_SUBSCRIPTION_CODE: ${{ inputs.subscription-code }}
+          VITE_SENTRY_RELEASE: ${{ steps.version.outputs.release }}
           npm_config_fetch_retry_mintimeout: 30000
           npm_config_fetch_retries: 5
-
-      - id: version
-        name: compute version
-        run: |
-          version="$(date +"%Y.%m.%d")-${{ github.run_number }}"
-          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: npm publish
         working-directory: packages/n3o-elements
@@ -83,6 +86,6 @@ jobs:
         uses: n3oltd/actions/.github/actions/n3o-sentry-release@main
         with:
           project: ${{ inputs.sentry-project }}
-          release: platforms-js@${{ steps.version.outputs.version }}-${{ inputs.subscription-code }}
+          release: ${{ steps.version.outputs.release }}
           sourcemaps: packages/n3o-elements/dist
           auth-token: ${{ env.SENTRY_AUTH_TOKEN }}

--- a/docker/n3o-react
+++ b/docker/n3o-react
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get install -y \
 ARG REACT_APP_SENTRY_RELEASE
 
 ENV REACT_APP_SENTRY_RELEASE=${REACT_APP_SENTRY_RELEASE} \
-    NODE_OPTIONS=--max-old-space-size=4096
+    NODE_OPTIONS=--max-old-space-size=4096 \
+    GENERATE_SOURCEMAP=true
 
 COPY package.json package-lock.json .npmrc ./
 
@@ -30,10 +31,16 @@ COPY . .
 ENV NODE_ENV=production
 
 RUN --mount=type=secret,id=github_token,required=true \
-    --mount=type=secret,id=sentry_auth_token,required=true \
     GITHUB_TOKEN="$(cat /run/secrets/github_token)" \
-    SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" \
     npm run build
+
+########################
+### sourcemaps
+### exported via `--output type=local,dest=...` for upload by CI
+########################
+FROM scratch AS sourcemaps
+
+COPY --from=builder /app/build/static/js/ /
 
 ########################
 ### final
@@ -45,6 +52,8 @@ WORKDIR /app
 RUN npm install express@latest
 
 COPY --from=builder /app/build ./build
+RUN find ./build -name '*.map' -delete
+
 COPY server.js ./
 
 EXPOSE 3000

--- a/docker/n3o-vite
+++ b/docker/n3o-vite
@@ -23,6 +23,15 @@ RUN npm run build
 RUN npm prune --omit=dev
 
 ########################
+### sourcemaps
+### exported via `--output type=local,dest=...` for upload by CI
+### (requires vite.config to set build.sourcemap: true)
+########################
+FROM scratch AS sourcemaps
+
+COPY --from=builder /app/dist/ /
+
+########################
 ### final
 ########################
 FROM base AS final
@@ -34,6 +43,8 @@ COPY --from=builder --chown=node:node /app/node_modules ./node_modules
 COPY --from=builder --chown=node:node /app/dist ./dist
 COPY --from=builder --chown=node:node /app/dist-server ./dist-server
 COPY --from=builder --chown=node:node /app/package.json ./package.json
+
+RUN find ./dist -name '*.map' -delete 2>/dev/null || true
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary

Refactor so source map upload is owned by CI (the `n3o-sentry-release` composite) rather than by each app's bundler plugin. Apps just enable sourcemap generation in their build config; the shared workflow extracts the sourcemaps from the built container and uploads them.

## What lands here

### Dockerfile changes
- `docker/n3o-react`: new `sourcemaps` scratch stage exposing `/app/build/static/js`; `GENERATE_SOURCEMAP=true` in builder; `.map` files stripped from the final runtime image.
- `docker/n3o-vite`: same pattern, exposing `/app/dist`. Consumers must set `build.sourcemap: true` in their `vite.config`.

### Workflow changes
- **`n3o-docker-build-push.yml`**: new `sentry-extract-sourcemaps` boolean input. When `true` (and `sentry-project` set), runs a second `docker/build-push-action@v7` targeting the `sourcemaps` stage and writing to `${{ runner.temp }}/sourcemaps`. The composite then uploads from that path. Backend services keep the existing single-build flow (default `false`).
- **`n3o-platforms-js-build-push.yml`**: optional `sentry-project` input. When set, after `npm publish` the composite creates a release `platforms-js@<version>-<subscription>` in the named project, with sourcemaps uploaded from `packages/n3o-elements/dist`. Version is now computed once and shared between publish and Sentry.

## Why

- Apps stay Sentry-agnostic in their build config (no more `SentryWebpackPlugin` / `sentryVitePlugin` per app).
- Auth tokens stay in CI secrets — never hardcoded in app code (the current `sentryVitePlugin` config in fe-platforms has a hardcoded auth token; this refactor lets us delete it).
- One mental model: composite handles everything (release, commits, repo registration, source map upload, deploy events, Debug ID injection).
- New React/Vite apps get full Sentry support by passing `sentry-project: X` + `sentry-extract-sourcemaps: true` — no plugin config to copy.

## Follow-up PRs (after merge)

- `svc-fe-engage`: remove SentryWebpackPlugin from config-overrides.js; pass `sentry-extract-sourcemaps: true` (PR to me).
- `svc-fe-link-builder`: enable `build.sourcemap: true` in vite.config; pass `sentry-extract-sourcemaps: true` (PR to me).
- `fe-platforms`: remove `sentryVitePlugin` (and the hardcoded auth token) from vite.config.ts; pass `sentry-project: scripts` in platforms-js-ci.yml (PR to waheed-n3o + haseeb5i).

## Test plan

- [ ] Land this PR.
- [ ] Manually trigger an engage build with the follow-up PR — confirm sourcemaps appear on the corresponding release in the `frontend` Sentry project.
- [ ] Manually trigger a link-builder build with its follow-up — confirm sourcemaps appear on the `frontend` release.
- [ ] Trigger a platforms-js build for one subscription with the fe-platforms follow-up — confirm release `platforms-js@<version>-<sub>` appears in the `scripts` project with sourcemaps.
- [ ] Backend service builds (svc-be-*) unaffected — `sentry-extract-sourcemaps` defaults to `false`.