### PR TITLE
dotnet-build-pack-push: declare sentry-auth-token as a workflow secret

### DIFF
--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -57,8 +57,8 @@ on:
       nuget-api-key:
         required: false
 
-env:
-  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      sentry-auth-token:
+        required: false
 
 jobs:
   job1:
@@ -125,4 +125,4 @@ jobs:
         with:
           project: ${{ inputs.sentry-project }}
           release: ${{ github.event.repository.name }}@${{ steps.prepare.outputs.VERSION }}
-          auth-token: ${{ env.SENTRY_AUTH_TOKEN }}
+          auth-token: ${{ secrets.sentry-auth-token }}


### PR DESCRIPTION
## Summary

Fix for the umbraco-extensions Main CI failure: https://github.com/n3oltd/umbraco-extensions/actions/runs/26710019237.

## What was broken

PR #64 enabled an optional Sentry release step in `dotnet-build-pack-push.yml`, reading `SENTRY_AUTH_TOKEN` via a workflow-level `env:` block. In a **reusable workflow with an explicit `on.workflow_call.secrets:` block** (which this workflow has — for `nuget-api-key`), `${{ secrets.X }}` only resolves when either:
- the caller uses `secrets: inherit`, or
- the secret is declared in the reusable workflow's `secrets:` block and explicitly passed by the caller.

Neither applies for umbraco-extensions' main-ci. So `SENTRY_AUTH_TOKEN` came through as empty string → sentry-cli reported "Environment variable SENTRY_AUTH_TOKEN is missing an auth token" → build failed.

## Fix

Declare `sentry-auth-token` (optional) in this workflow's secrets block; reference it as `${{ secrets.sentry-auth-token }}` on the composite call. Mirrors how `nuget-api-key` is already wired here, and how `sentry-auth-token` is wired on sites' `docker-build-push.yml`. Removes the now-redundant `env: SENTRY_AUTH_TOKEN` block at workflow level.

## Companion PR

n3oltd/umbraco-extensions adds the corresponding `sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}` to its main-ci.yml secrets passthrough.

## Test plan

- [ ] Merge this + the umbraco PR.
- [ ] Trigger umbraco-extensions main-ci.yml.
- [ ] Confirm the run succeeds + a release `umbraco-extensions@<version>` lands in the `sites` Sentry project with commits attached.