### PR TITLE
n3o-cli-install: export AZURE_* to GITHUB_ENV

### DIFF
--- a/.github/actions/n3o-cli-install/action.yml
+++ b/.github/actions/n3o-cli-install/action.yml
@@ -28,3 +28,8 @@ runs:
         dotnet nuget add source https://nuget.pkg.github.com/n3oltd/index.json --name n3oltd --username n3oltd --password ${{ inputs.access-token }} --store-password-in-clear-text
         dotnet tool install --global --no-cache n3o
         echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+        {
+          echo "AZURE_CLIENT_ID=${{ inputs.azure-client-id }}"
+          echo "AZURE_CLIENT_SECRET=${{ inputs.azure-client-secret }}"
+          echo "AZURE_TENANT_ID=${{ inputs.azure-tenant-id }}"
+        } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

The n3o cli loads its config from the \`n3o-cli\` Azure key vault on every startup, so any step that runs \`n3o ...\` needs \`AZURE_CLIENT_ID\` / \`AZURE_CLIENT_SECRET\` / \`AZURE_TENANT_ID\` in its environment — not just the install step itself.

Previously each caller had to repeat the three \`env:\` entries on every step that invoked \`n3o\`. Caught in n3oltd/work where \`stage-sync-cron\`, \`aging-stall\`, and \`awaiting-verification\` are all failing on first run with:

\`\`\`
CredentialUnavailableException: DefaultAzureCredential failed to retrieve a token
- EnvironmentCredential authentication unavailable. Environment variables are not fully configured.
- ManagedIdentityCredential authentication unavailable. ...
\`\`\`

This PR has the install action write the three Azure env vars to \`\$GITHUB_ENV\` so every subsequent step in the same job inherits them automatically. Idiomatic for a tool-install action to configure the environment its tool needs — mirrors how \`actions/setup-node\` extends \`PATH\` or \`actions/setup-python\` sets \`pythonLocation\`.

\`\$GITHUB_ENV\` is job-scoped (no leak to other jobs in the workflow) and GitHub masks the secret values in logs.

## Test plan

- [ ] On merge: re-trigger \`workflow_dispatch\` on n3oltd/work \`stage-sync-cron.yml\` and confirm it gets past Azure auth (succeeds or fails for a different reason)
- [ ] No regression in existing callers — they pass the same inputs as before, just don't strictly need to also set the env vars on later steps any more (idempotent; per-step env: blocks still work and take precedence)