### PR TITLE
n3o-cli-install: export AZURE_* to GITHUB_ENV (with caller cleanup)

### DIFF
--- a/.github/actions/n3o-cli-install/action.yml
+++ b/.github/actions/n3o-cli-install/action.yml
@@ -28,3 +28,8 @@ runs:
         dotnet nuget add source https://nuget.pkg.github.com/n3oltd/index.json --name n3oltd --username n3oltd --password ${{ inputs.access-token }} --store-password-in-clear-text
         dotnet tool install --global --no-cache n3o
         echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+        {
+          echo "AZURE_CLIENT_ID=${{ inputs.azure-client-id }}"
+          echo "AZURE_CLIENT_SECRET=${{ inputs.azure-client-secret }}"
+          echo "AZURE_TENANT_ID=${{ inputs.azure-tenant-id }}"
+        } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Reopen of the closed #69 after audit of the existing caller pattern. The n3o cli loads its config from the \`n3o-cli\` Azure key vault on every startup, so every step that runs \`n3o ...\` needs \`AZURE_CLIENT_ID\` / \`AZURE_CLIENT_SECRET\` / \`AZURE_TENANT_ID\` in its environment. Today every caller restates the three secrets in its own \`env:\` block, which:

- duplicates ~3 lines per callsite × dozens of workflows
- is easy to forget (caught on n3oltd/work where 12 workflows were missing the declarations — scheduled cron jobs have been failing on every run with \`CredentialUnavailableException\`)
- makes the contract implicit: "if I run n3o, I must remember to set its env"

This PR has the install action write the three Azure env vars to \`\$GITHUB_ENV\` so every subsequent step in the same job inherits them. Mirrors how \`actions/setup-node\` extends \`PATH\` or \`actions/setup-python\` sets \`pythonLocation\` — tool installers configure their tool's env.

### Security note

\`GITHUB_ENV\` is job-scoped (no leak to other jobs in the workflow run), and GitHub masks the secret values in logs. Marginal defense-in-depth loss vs the per-step \`env:\` pattern, but in practice negligible: a step in the same job that wants secrets can already read them via the \`\${{ secrets.* }}\` context, regardless of which step's env block contains them.

### Backward compatibility

Fully additive. Existing callers that still declare \`env: AZURE_*\` on their \`n3o\` steps continue to work — re-declaration with the same values is idempotent. The follow-up cleanup (separate PRs per repo) strips the redundant blocks but isn't required for this PR to be safe to merge.

## Test plan

- [ ] CI green
- [ ] On merge: re-trigger \`workflow_dispatch\` on n3oltd/work \`stage-sync-cron.yml\` and confirm the previously-failing scheduled jobs get past Azure auth
- [ ] Follow-up cleanup PRs per repo strip redundant per-step env: AZURE_* blocks (n3oltd/work, n3oltd/actions, n3oltd/devops, …)