### PR TITLE
Authenticate nuget upgrade as N3O Babar app; skip work-dispatch for bots

### DIFF
--- a/.github/workflows/n3o-dotnet-update-nuget.yml
+++ b/.github/workflows/n3o-dotnet-update-nuget.yml
@@ -13,6 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.N3O_APP_ID }}
+          private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
+          owner: n3oltd
+
       - name: setup-dotnet
         uses: actions/setup-dotnet@v5
         with:
@@ -21,15 +29,18 @@ jobs:
       - name: install n3o cli
         uses: n3oltd/actions/.github/actions/n3o-cli-install@main
         with:
-          access-token: ${{ secrets.GH_PAT }}
+          access-token: ${{ steps.app-token.outputs.token }}
 
       - name: upgrade
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
+          GH_PAT: ${{ steps.app-token.outputs.token }}
           AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
         run: |
+          git config --global user.name "N3O Babar"
+          git config --global user.email "292859849+n3o-babar[bot]@users.noreply.github.com"
+
           if [ -n "${{ inputs.repo }}" ]; then
             n3o nuget upgrade --our-packages --target=remote --repo="${{ inputs.repo }}" --script
           else

--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   pr:
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'n3o-babar[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -48,7 +51,11 @@ jobs:
             $flags
 
   push:
-    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+      github.actor != 'n3o-babar[bot]' &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What

Phase 1 of getting the **n3o-github break-glass account** out of routine CI and cutting wasted Actions minutes.

### 1. `n3o-dotnet-update-nuget.yml` — auth as the `N3O Babar` GitHub App
- Mints an installation token via `actions/create-github-app-token@v2` (`N3O_APP_ID` / `N3O_APP_PRIVATE_KEY`, org-scoped) instead of `secrets.GH_PAT`.
- Token is used for both the nuget source auth (`n3o-cli-install`) and the `n3o nuget upgrade` step.
- Commits are attributed to `n3o-babar[bot]` (git author set explicitly).

### 2. `n3o-work-dispatch.yml` — skip bot-authored events
- `pr` and `push` jobs now exclude `dependabot[bot]` and `n3o-babar[bot]`.
- A false job-level `if:` is **skipped without acquiring a runner → zero billed minutes**, so the no-op dispatch runs for every Dependabot PR and every nuget-upgrade commit stop costing money.

## Why
Dependabot PRs + the scheduled nuget upgrade never close `n3oltd/work` issues, so `work-dispatch` was always a no-op for them — but still paid full `setup-dotnet` + n3o CLI install on every event, across every repo. The upgrade also ran as the break-glass admin's PAT.

## Prereqs (done)
- `N3O Babar` App created (App ID `4030053`), installed on all `@n3oltd` repos.
- Org secrets `N3O_APP_ID` / `N3O_APP_PRIVATE_KEY` set (visibility: private, matching `GH_PAT`).

## Verify after merge
1. `workflow_dispatch` the upgrade against one repo (`--repo` input) → commit authored by `n3o-babar[bot]`, `github.actor == n3o-babar[bot]`.
2. Triggered `work-dispatch` run shows **skipped** (no runner consumed).
3. A Dependabot PR's `work-dispatch` pr-job is skipped.

## Not in scope (tracked separately)
Phase 2/3 — migrating the other actor-writes (generate-all-clients, work dispatch, label sync, triage, add-to-projects) and the build/package/checkout/docker credentials off `GH_PAT`, then retiring the break-glass PAT.