### PR TITLE
Phase 2: actor-write reusables → N3O Babar app (work-dispatch, triage, generate-clients)

### DIFF
--- a/.github/workflows/n3o-auto-triage-issues.yml
+++ b/.github/workflows/n3o-auto-triage-issues.yml
@@ -14,9 +14,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.N3O_APP_ID }}
+          private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
+          owner: n3oltd
+
       - name: apply triage label
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \

--- a/.github/workflows/n3o-dotnet-generate-clients.yml
+++ b/.github/workflows/n3o-dotnet-generate-clients.yml
@@ -8,7 +8,6 @@ on:
         default: src
 
 env:
-  GH_PAT: ${{ secrets.GH_PAT }}
   AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
   AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
   AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
@@ -22,10 +21,18 @@ jobs:
       cancel-in-progress: false
 
     steps:
+      - name: app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.N3O_APP_ID }}
+          private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
+          owner: n3oltd
+
       - name: checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ env.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: setup-dotnet
         uses: actions/setup-dotnet@v5
@@ -40,7 +47,7 @@ jobs:
       - name: install n3o cli
         uses: n3oltd/actions/.github/actions/n3o-cli-install@main
         with:
-          access-token: ${{ env.GH_PAT }}
+          access-token: ${{ steps.app-token.outputs.token }}
           azure-client-id: ${{ env.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ env.AZURE_CLIENT_SECRET }}
           azure-tenant-id: ${{ env.AZURE_TENANT_ID }}
@@ -55,8 +62,8 @@ jobs:
 
       - name: commit if changed
         run: |
-          git config user.name 'n3o-bot'
-          git config user.email 'bot@n3o.ltd'
+          git config user.name 'N3O Babar'
+          git config user.email '292859849+n3o-babar[bot]@users.noreply.github.com'
 
           if git diff --quiet; then
             echo 'No client changes.'

--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -12,6 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.N3O_APP_ID }}
+          private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
+          owner: n3oltd
+
       - name: setup-dotnet
         uses: actions/setup-dotnet@v5
         with:
@@ -20,14 +28,14 @@ jobs:
       - name: install n3o cli
         uses: n3oltd/actions/.github/actions/n3o-cli-install@main
         with:
-          access-token: ${{ secrets.GH_PAT }}
+          access-token: ${{ steps.app-token.outputs.token }}
           azure-client-id: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
           azure-tenant-id: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
 
       - name: dispatch PR references
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
@@ -59,6 +67,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.N3O_APP_ID }}
+          private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
+          owner: n3oltd
+
       - name: setup-dotnet
         uses: actions/setup-dotnet@v5
         with:
@@ -67,14 +83,14 @@ jobs:
       - name: install n3o cli
         uses: n3oltd/actions/.github/actions/n3o-cli-install@main
         with:
-          access-token: ${{ secrets.GH_PAT }}
+          access-token: ${{ steps.app-token.outputs.token }}
           azure-client-id: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
           azure-tenant-id: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
 
       - name: dispatch commit references
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
Part of n3oltd/work#734. Replaces the **n3o-github break-glass `GH_PAT`** with `N3O Babar` app installation tokens in the reusables that write as an actor.

| Reusable | Was | Now |
|---|---|---|
| `n3o-work-dispatch.yml` | `n3o work pr/commit-dispatch` on `GH_PAT` | app token (per-job), Issues:write on `n3oltd/work` |
| `n3o-auto-triage-issues.yml` | `gh issue edit` on `GH_PAT` | app token |
| `n3o-dotnet-generate-clients.yml` | checkout + push + CLI on `GH_PAT`; commit as `n3o-bot` | app token; commit authored `n3o-babar[bot]` |

Each job mints its own org-scoped token via `actions/create-github-app-token@v2` (`N3O_APP_ID` / `N3O_APP_PRIVATE_KEY`, already set, private visibility = parity with `GH_PAT`). App perms in place: Issues R/W, Contents R/W, Packages R/W, metadata.

**Side benefit:** generate-clients commits now push as `n3o-babar[bot]`, so the Phase 1 work-dispatch actor filter skips them too (previously ran as `n3o-github` → no-op runner).

### Verify after merge
- Open a test PR referencing a `n3oltd/work` issue → confirm dispatch still posts, run authed as the app.
- Open an unlabelled issue in a repo that calls auto-triage → `status/needs-triage` applied.
- `workflow_dispatch` generate-clients on one repo → client commit authored `n3o-babar[bot]`, pushes successfully.