### PR TITLE
Revert n3o-cli-install access-token to GH_PAT

### DIFF
--- a/.github/workflows/n3o-dotnet-generate-clients.yml
+++ b/.github/workflows/n3o-dotnet-generate-clients.yml
@@ -47,7 +47,7 @@ jobs:
       - name: install n3o cli
         uses: n3oltd/actions/.github/actions/n3o-cli-install@main
         with:
-          access-token: ${{ steps.app-token.outputs.token }}
+          access-token: ${{ secrets.GH_PAT }}
           azure-client-id: ${{ env.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ env.AZURE_CLIENT_SECRET }}
           azure-tenant-id: ${{ env.AZURE_TENANT_ID }}

--- a/.github/workflows/n3o-dotnet-update-nuget.yml
+++ b/.github/workflows/n3o-dotnet-update-nuget.yml
@@ -29,7 +29,7 @@ jobs:
       - name: install n3o cli
         uses: n3oltd/actions/.github/actions/n3o-cli-install@main
         with:
-          access-token: ${{ steps.app-token.outputs.token }}
+          access-token: ${{ secrets.GH_PAT }}
 
       - name: upgrade
         env:

--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -28,7 +28,7 @@ jobs:
       - name: install n3o cli
         uses: n3oltd/actions/.github/actions/n3o-cli-install@main
         with:
-          access-token: ${{ steps.app-token.outputs.token }}
+          access-token: ${{ secrets.GH_PAT }}
           azure-client-id: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
           azure-tenant-id: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
@@ -83,7 +83,7 @@ jobs:
       - name: install n3o cli
         uses: n3oltd/actions/.github/actions/n3o-cli-install@main
         with:
-          access-token: ${{ steps.app-token.outputs.token }}
+          access-token: ${{ secrets.GH_PAT }}
           azure-client-id: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
           azure-tenant-id: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}


### PR DESCRIPTION
## Problem

Every workflow that installs the n3o CLI is failing at the install step with `403 (Forbidden)` (e.g. [svc-be-subscriptions run](https://github.com/n3oltd/svc-be-subscriptions/actions/runs/27399270418)). #72/#73 switched the `n3o-cli-install` `access-token` to an N3O Babar installation token, which is used as the password for `nuget.pkg.github.com` — and the GitHub Packages nuget registry does not accept GitHub App installation tokens (verified during the Phase 3 investigation: app token → 403, PAT → 200; see closed work#734).

## Fix

Revert only the `access-token` input back to `secrets.GH_PAT` (package feed read) in `n3o-work-dispatch` (both jobs), `n3o-dotnet-update-nuget` and `n3o-dotnet-generate-clients`. The Babar token stays for checkout, commits/pushes and GitHub API calls, so bot attribution and the dependabot/babar skip filters are unaffected.

## Verification

After merge (callers reference `@main`), re-run the failed work-dispatch run above and confirm the next scheduled nuget upgrade passes.