### PR TITLE
Standardize npm auth on GH_PAT (vite + react Dockerfiles)

### DIFF
--- a/docker/n3o-react
+++ b/docker/n3o-react
@@ -23,7 +23,7 @@ ENV REACT_APP_SENTRY_RELEASE=${REACT_APP_SENTRY_RELEASE} \
 COPY package.json package-lock.json .npmrc ./
 
 RUN --mount=type=secret,id=github_token,required=true \
-    GITHUB_TOKEN="$(cat /run/secrets/github_token)" \
+    GH_PAT="$(cat /run/secrets/github_token)" \
     npm ci
 
 COPY . .
@@ -31,7 +31,7 @@ COPY . .
 ENV NODE_ENV=production
 
 RUN --mount=type=secret,id=github_token,required=true \
-    GITHUB_TOKEN="$(cat /run/secrets/github_token)" \
+    GH_PAT="$(cat /run/secrets/github_token)" \
     npm run build
 
 ########################

--- a/docker/n3o-vite
+++ b/docker/n3o-vite
@@ -13,7 +13,7 @@ FROM base AS builder
 COPY package.json package-lock.json .npmrc ./
 
 RUN --mount=type=secret,id=github_token,required=true \
-    GITHUB_TOKEN="$(cat /run/secrets/github_token)" \
+    GH_PAT="$(cat /run/secrets/github_token)" \
     npm ci
 
 COPY . .


### PR DESCRIPTION
## Problem
`npm ci` in `svc-fe-link-builder` CI started failing with `401 Unauthorized` fetching `@n3oltd` GitHub Packages.

Root cause: the npm token is named inconsistently across the two contexts that consume a project's committed `.npmrc`:
- **CI** (`n3o-vite-ci.yml`): exports the token as `GH_PAT`
- **Docker build** (`n3o-vite` / `n3o-react` Dockerfiles): exposed it as `GITHUB_TOKEN`

A single static `.npmrc` can only reference one env var name. When `.npmrc` was switched to `${GITHUB_TOKEN}` (to satisfy the Docker build), CI broke because that workflow only exports `GH_PAT`.

## Fix
Expose the `github_token` docker secret as **`GH_PAT`** in both Dockerfiles so `.npmrc` can use `${GH_PAT}` consistently in CI and container builds. This matches `n3o-vite-ci.yml`, `n3o-react-build.yml`, `n3o-docker-build-push.yml`, and `fe-platforms`.

Companion `.npmrc` PRs: svc-fe-link-builder, svc-fe-work, svc-fe-engage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)