### PR TITLE
Use github.token for built-in auth in n3o-aks-deployment

### DIFF
--- a/.github/workflows/n3o-aks-deployment.yml
+++ b/.github/workflows/n3o-aks-deployment.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install and configure kubectl with AKS
         uses: n3oltd/actions/.github/actions/n3o-kubectl-setup@main
         with:
-          access-token: ${{ secrets.GITHUB_TOKEN }}
+          access-token: ${{ github.token }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           resource-group: ${{ inputs.data-region }}
 


### PR DESCRIPTION
Replaces `secrets.GITHUB_TOKEN` with `${{ github.token }}` for the `access-token` input passed into `n3o-kubectl-setup` (used by `azure/use-kubelogin` to download the kubelogin binary). Identical built-in token, no behavior change.

The env var name `GITHUB_TOKEN` inside `n3o-kubectl-setup/action.yml` is intentionally **kept** — `azure/use-kubelogin` reads an env var with that exact name. Its value now flows from `github.token` via the caller.

Companion to the npm-auth standardization (#76): `GH_PAT` for cross-repo/npm, `github.token` for the built-in same-repo token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)