### PR TITLE
n3o-work-dispatch: ship-on-merge release for `internal` repos

### DIFF
--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -1,7 +1,17 @@
 name: 'n3o-work-dispatch'
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      ship-on-merge:
+        description: >-
+          For `internal` ship-on-merge repos (no `n3o deploy` step — the n3o CLI,
+          shared actions, devops). When true, merging to the default branch
+          releases the referenced n3oltd/work issues straight to Released to Prod.
+          Leave false (default) for customer-facing repos that release via n3o deploy.
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   pr:
@@ -58,6 +68,36 @@ jobs:
             --default-branch "${{ github.event.repository.default_branch }}" \
             $flags
 
+      - name: release referenced issues (ship-on-merge)
+        if: inputs.ship-on-merge && github.event.pull_request.merged == true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # `internal` (ship-on-merge) repos have no `n3o deploy` step: merging to
+          # the default branch IS the prod release. Move each n3oltd/work issue
+          # referenced by this merged PR straight to Released to Prod. Parses the
+          # same PR title/body that pr-dispatch used to reach Merged. See n3oltd/work
+          # architecture.md §11 (Ship-on-merge products). mark-released is idempotent.
+          issues=$(printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" \
+            | grep -oiE 'n3oltd/work#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -un || true)
+
+          if [ -z "$issues" ]; then
+            echo "No n3oltd/work references in this PR; nothing to release."
+            exit 0
+          fi
+
+          for n in $issues; do
+            echo "ship-on-merge: releasing n3oltd/work#$n to prod"
+            n3o work mark-released --issue "$n" --env prod
+          done
+
   push:
     if: >-
       github.event_name == 'push' &&
@@ -102,3 +142,32 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --default-branch "${{ github.event.repository.default_branch }}" \
             --messages "$messages"
+
+      - name: release referenced issues (ship-on-merge)
+        if: inputs.ship-on-merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
+          COMMITS_JSON: ${{ toJSON(github.event.commits) }}
+        run: |
+          # Direct-push counterpart of the pr-job release step: release n3oltd/work
+          # issues referenced in the pushed commit messages (covers direct pushes to
+          # the default branch and squash-merges that carry the ref in the commit).
+          # mark-released is idempotent, so overlap with the pr-job step is harmless.
+          issues=$(echo "$COMMITS_JSON" \
+            | jq -r 'map(.message) | join("\n")' \
+            | grep -oiE 'n3oltd/work#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -un || true)
+
+          if [ -z "$issues" ]; then
+            echo "No n3oltd/work references in this push; nothing to release."
+            exit 0
+          fi
+
+          for n in $issues; do
+            echo "ship-on-merge: releasing n3oltd/work#$n to prod"
+            n3o work mark-released --issue "$n" --env prod
+          done

--- a/.github/workflows/work-dispatch.yml
+++ b/.github/workflows/work-dispatch.yml
@@ -1,0 +1,17 @@
+name: Dispatch PR status to n3oltd/work
+
+on:
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review, converted_to_draft]
+  push:
+
+jobs:
+  dispatch:
+    # Local reference (not @main) so this repo always runs the reusable from the
+    # same ref — keeps it consistent on PRs/branches and avoids a chicken-and-egg
+    # with new reusable inputs. `internal` ship-on-merge repo: merge to main is
+    # the release (see n3oltd/work architecture.md §11).
+    uses: ./.github/workflows/n3o-work-dispatch.yml
+    with:
+      ship-on-merge: true
+    secrets: inherit


### PR DESCRIPTION
## Why

Internal repos that ship on merge to `main` — the **n3o CLI** (`n3oltd/cli`), **this repo** (`n3oltd/actions`), and **devops** (`n3oltd/devops`) — have no `n3o deploy` step. Consumers install them from `@main`, so a merge to `main` *is* the production release. But the work tracker only advances an issue past `Merged` on a release event from `n3o deploy`, so these repos' issues (e.g. the deploy-command fix tracked in `n3oltd/work#761`) strand at `Merged` forever — never reaching Released to Prod or Done.

This is the new `internal` Product / ship-on-merge model. Docs: **n3oltd/work#764**.

## What this does

- Adds a `ship-on-merge` boolean input to the reusable `n3o-work-dispatch.yml` (default `false` — customer-facing service/site repos are unaffected).
- When `true`, the issue is released to prod on merge in **both** event paths, mirroring how Merged is reached today:
  - **`pr` job** — on a merged PR, parses the PR title/body (same text `pr-dispatch` uses) and runs `n3o work mark-released --issue NNN --env prod` for each `n3oltd/work#NNN`.
  - **`push` job** — for direct pushes / squash-merges that carry the ref in the commit, parses commit messages and does the same.
  - `mark-released` is idempotent, so the overlap on a squash-merge is harmless.
- Adds this repo's own `work-dispatch.yml` caller (it had none) with `ship-on-merge: true`, using a **local** reusable reference so it stays consistent on branches/PRs.

Stage goes `Merged → Released to Prod` + stamps `Released to Prod at`. Verifier attention comes from the daily `awaiting-verification` pass (tags `@n3oltd/verifiers` at Released to Prod).

## Merge order

This PR is self-contained (the new input + the local-path self-caller are on the same branch, so CI is green here). The **caller PRs in `n3oltd/cli` and `n3oltd/devops`** add `with: ship-on-merge: true` against `…@main`, so **merge this PR first** — their dispatch runs go green once the input exists on `main`.

## Future enhancement (backend)

The full-fidelity path would teach the `release-shipped` handler in `Karakoram.Work` about a product-scoped `internal` target (giving the immediate verifier comment-tag and 7-day QA-carry auto-close). Until then, `mark-released` + the daily pass cover it. The release logic lives in the backend NuGet, not this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)