### PR TITLE
work-dispatch: drop doc-section refs from YAML comments

### DIFF
--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -78,11 +78,10 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # `internal` (ship-on-merge) repos have no `n3o deploy` step: merging to
-          # the default branch IS the prod release. Move each n3oltd/work issue
-          # referenced by this merged PR straight to Released to Prod. Parses the
-          # same PR title/body that pr-dispatch used to reach Merged. See n3oltd/work
-          # architecture.md §11 (Ship-on-merge products). mark-released is idempotent.
+          # ship-on-merge: merging to the default branch IS the prod release for
+          # these repos. Move each n3oltd/work issue referenced by this merged PR
+          # straight to Released to Prod, parsing the same PR title/body that
+          # pr-dispatch used to reach Merged. mark-released is idempotent.
           issues=$(printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" \
             | grep -oiE 'n3oltd/work#[0-9]+' \
             | grep -oE '[0-9]+' \

--- a/.github/workflows/work-dispatch.yml
+++ b/.github/workflows/work-dispatch.yml
@@ -9,8 +9,7 @@ jobs:
   dispatch:
     # Local reference (not @main) so this repo always runs the reusable from the
     # same ref — keeps it consistent on PRs/branches and avoids a chicken-and-egg
-    # with new reusable inputs. `internal` ship-on-merge repo: merge to main is
-    # the release (see n3oltd/work architecture.md §11).
+    # with new reusable inputs. ship-on-merge: merge to main is the release.
     uses: ./.github/workflows/n3o-work-dispatch.yml
     with:
       ship-on-merge: true


### PR DESCRIPTION
Follow-up to #78 (already merged). Removes the `architecture.md §11` / doc-section citations from the workflow YAML comments — they go stale and add little value. Keeps the concise functional comments. No behaviour change.