### PR TITLE
work-dispatch: drop the self-caller comment

### DIFF
--- a/.github/workflows/work-dispatch.yml
+++ b/.github/workflows/work-dispatch.yml
@@ -7,9 +7,6 @@ on:
 
 jobs:
   dispatch:
-    # Local reference (not @main) so this repo always runs the reusable from the
-    # same ref — keeps it consistent on PRs/branches and avoids a chicken-and-egg
-    # with new reusable inputs. ship-on-merge: merge to main is the release.
     uses: ./.github/workflows/n3o-work-dispatch.yml
     with:
       ship-on-merge: true


### PR DESCRIPTION
Removes the local-reference explanation comment from this repo's `work-dispatch.yml` caller. No behaviour change.