### PR TITLE
Authenticate NuGet restore in generate-clients build steps

### DIFF
--- a/.github/workflows/n3o-dotnet-generate-clients.yml
+++ b/.github/workflows/n3o-dotnet-generate-clients.yml
@@ -52,6 +52,13 @@ jobs:
           azure-client-secret: ${{ env.AZURE_CLIENT_SECRET }}
           azure-tenant-id: ${{ env.AZURE_TENANT_ID }}
 
+      - name: dotnet build
+        uses: n3oltd/actions/.github/actions/dotnet-restore-build@main
+        with:
+          access-token: ${{ secrets.GH_PAT }}
+          build-configuration: Debug
+          working-directory: ${{ inputs.working-directory }}
+
       - name: generate clients
         working-directory: ${{ inputs.working-directory }}
         run: n3o generate clients


### PR DESCRIPTION
## Problem

`generate-clients` failed at `n3o generate clients` with (surfaced via [n3oltd/cli#112](https://github.com/n3oltd/cli/pull/112)):

```
Response status code does not indicate success: 401 (Unauthorized).
'https://nuget.pkg.github.com/n3oltd/download/karakoram.framework.web/index.json'
```

Each repo's `NuGet.Config` authenticates the private `n3oltd` GitHub Packages feed via environment substitution:

```xml
<n3oltd>
  <add key="Username" value="%GH_USERNAME%" />
  <add key="ClearTextPassword" value="%GH_PAT%" />
</n3oltd>
```

The CLI build and `verify build` ran without `GH_USERNAME`/`GH_PAT` in the environment, so restore sent empty credentials → 401 on every `Karakoram.*` package, before any client was generated.

## Fix

Add an authenticated **`dotnet-restore-build`** step before generation — the same action `main-ci` (`n3o-dotnet-build-pack-push`) and `main-pr` (`n3o-dotnet-build`) already restore through, which encapsulates `GH_USERNAME: n3oltd` + `GH_PAT`. It restores the private feed into the package cache, so:

- `n3o generate clients` — the CLI's internal `dotnet build` is a no-op restore (cache hit), no credentials needed.
- `verify build` — likewise a no-op restore.

This keeps credential handling **centralised in the shared action** rather than inlined per step, consistent with every other dotnet workflow in the repo (`GH_USERNAME` is defined in exactly one place: `dotnet-restore-build`). Fixes generate-clients across all consuming repos (`@main`). Bot identity, checkout token, and push step unchanged.