### PR TITLE
feat: dispatch rollout-track to work on PR merge

### DIFF
--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -68,6 +68,19 @@ jobs:
             --default-branch "${{ github.event.repository.default_branch }}" \
             $flags
 
+      - name: dispatch rollout tracking
+        if: github.event.pull_request.merged == true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Rollout detection needs the PR diff, so the work repo runs it via the n3o CLI;
+          # it no-ops if the PR introduced no datafix or migration.
+          jq -n --arg repo "$PR_REPO" --argjson num "$PR_NUMBER" \
+            '{event_type: "rollout-track", client_payload: {pr_repo: $repo, pr_number: $num}}' \
+            | gh api repos/n3oltd/work/dispatches -X POST --input -
+
       - name: release referenced issues (ship-on-merge)
         if: inputs.ship-on-merge && github.event.pull_request.merged == true
         env:


### PR DESCRIPTION
Rollouts bot — the emitter side. Companion to n3oltd/work#2424.

## What this adds
A `dispatch rollout tracking` step in `n3o-work-dispatch.yml`, gated on `github.event.pull_request.merged == true`. On any merged PR it POSTs a `rollout-track` `repository_dispatch` to `n3oltd/work` with `{ pr_repo, pr_number }`. The work repo's `rollout-track.yml` then runs the rollout detectors over the PR diff — `n3o work track-datafix` now, `n3o work track-migration` in Phase 2 — each a no-op if the PR introduced none.

Detection needs the PR diff, so it runs in `work` via the `n3o` CLI rather than being gated on a work-issue reference here. Uses the existing `app-token` (Babar) — already minted in this workflow — only to POST the dispatch.

One umbrella `rollout-track` event (not per-type) so this shared-infra file is never re-touched as new rollout kinds are added — they slot into the work-side workflow.

Canonical issue: n3oltd/work#57.