### PR TITLE
chore: use --no-input instead of --script for n3o nuget upgrade

### DIFF
--- a/.github/workflows/n3o-dotnet-update-nuget.yml
+++ b/.github/workflows/n3o-dotnet-update-nuget.yml
@@ -42,7 +42,7 @@ jobs:
           git config --global user.email "292859849+n3o-babar[bot]@users.noreply.github.com"
 
           if [ -n "${{ inputs.repo }}" ]; then
-            n3o nuget upgrade --our-packages --target=remote --repo="${{ inputs.repo }}" --script
+            n3o nuget upgrade --our-packages --target=remote --repo="${{ inputs.repo }}" --no-input
           else
-            n3o nuget upgrade --our-packages --target=remote --script
+            n3o nuget upgrade --our-packages --target=remote --no-input
           fi


### PR DESCRIPTION
## What
Switches the `n3o nuget upgrade` call in the nightly NuGet-update workflow from `--script` to `--no-input` — the clearer name the CLI now uses for "run non-interactively" (part of the CLI output-channel work, work#2415).

## ⚠️ Merge order
**Merge this only after the cli has shipped `--no-input`.** `actions` runs against the currently-deployed `n3o` CLI; `--no-input` doesn't exist until the cli output-channels PR merges and publishes. Merging early would feed an unknown flag to the deployed CLI and break the nightly upgrade.

No rush: `--script` is kept as a permanent alias, so the workflow keeps working unchanged until then — this is just the cosmetic switch to the preferred name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)