### PR TITLE
Add n3o-git-identity composite action and consolidate identity

### DIFF
--- a/.github/actions/n3o-git-identity/action.yml
+++ b/.github/actions/n3o-git-identity/action.yml
@@ -1,0 +1,21 @@
+name: n3o-git-identity
+description: Configures the canonical N3O Babar git identity used by N3O automation commits.
+
+inputs:
+  name:
+    description: git user.name to set
+    required: false
+    default: "N3O Babar"
+  email:
+    description: git user.email to set
+    required: false
+    default: "292859849+n3o-babar[bot]@users.noreply.github.com"
+
+runs:
+  using: "composite"
+  steps:
+    - name: configure git identity
+      shell: bash
+      run: |
+        git config --global user.name "${{ inputs.name }}"
+        git config --global user.email "${{ inputs.email }}"

--- a/.github/workflows/n3o-dotnet-generate-clients.yml
+++ b/.github/workflows/n3o-dotnet-generate-clients.yml
@@ -67,11 +67,11 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         run: dotnet build --nologo
 
+      - name: configure git identity
+        uses: n3oltd/actions/.github/actions/n3o-git-identity@main
+
       - name: commit if changed
         run: |
-          git config user.name 'N3O Babar'
-          git config user.email '292859849+n3o-babar[bot]@users.noreply.github.com'
-
           if git diff --quiet; then
             echo 'No client changes.'
             exit 0

--- a/.github/workflows/n3o-dotnet-update-nuget.yml
+++ b/.github/workflows/n3o-dotnet-update-nuget.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           access-token: ${{ secrets.GH_PAT }}
 
+      - name: configure git identity
+        uses: n3oltd/actions/.github/actions/n3o-git-identity@main
+
       - name: upgrade
         env:
           GH_PAT: ${{ steps.app-token.outputs.token }}
@@ -38,9 +41,6 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
         run: |
-          git config --global user.name "N3O Babar"
-          git config --global user.email "292859849+n3o-babar[bot]@users.noreply.github.com"
-
           if [ -n "${{ inputs.repo }}" ]; then
             n3o nuget upgrade --our-packages --target=remote --repo="${{ inputs.repo }}" --no-input
           else


### PR DESCRIPTION
Adds a `n3o-git-identity` composite action that sets the canonical **N3O Babar** identity (`N3O Babar` / `292859849+n3o-babar[bot]@users.noreply.github.com`) in one place, and adopts it in the two dotnet workflows.

Removes the duplicated, inline `git config user.name/user.email` strings. Companion PRs in `deployments`, `devops`, and `work` reference `n3oltd/actions/.github/actions/n3o-git-identity@main`, so **merge this first**.

- New `.github/actions/n3o-git-identity/action.yml`
- `n3o-dotnet-update-nuget.yml`, `n3o-dotnet-generate-clients.yml`: use the action