### PR TITLE
Fold App-token minting + push auth into n3o-git-identity

### DIFF
--- a/.github/actions/n3o-git-identity/action.yml
+++ b/.github/actions/n3o-git-identity/action.yml
@@ -1,21 +1,55 @@
 name: n3o-git-identity
-description: Configures the canonical N3O Babar git identity used by N3O automation commits.
+description: >-
+  Configures git for N3O automation commits: sets the canonical N3O Babar
+  identity and, when App credentials are supplied, mints an n3o-babar App token
+  and configures authenticated github.com pushes (so the commits are verified).
 
 inputs:
+  app-id:
+    description: n3o-babar GitHub App id. When set (with private-key), an App token is minted for verified, authenticated pushes.
+    required: false
+    default: ""
+  private-key:
+    description: n3o-babar GitHub App private key.
+    required: false
+    default: ""
+  owner:
+    description: Owner/org the minted token is scoped to.
+    required: false
+    default: n3oltd
   name:
-    description: git user.name to set
+    description: git user.name to set.
     required: false
     default: "N3O Babar"
   email:
-    description: git user.email to set
+    description: git user.email to set.
     required: false
     default: "292859849+n3o-babar[bot]@users.noreply.github.com"
+
+outputs:
+  token:
+    description: The minted App installation token (empty when no App credentials were supplied).
+    value: ${{ steps.app-token.outputs.token }}
 
 runs:
   using: "composite"
   steps:
-    - name: configure git identity
+    - name: mint app token
+      id: app-token
+      if: inputs.app-id != ''
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+
+    - name: configure git
       shell: bash
+      env:
+        N3O_GIT_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         git config --global user.name "${{ inputs.name }}"
         git config --global user.email "${{ inputs.email }}"
+        if [ -n "$N3O_GIT_TOKEN" ]; then
+          git config --global url."https://x-access-token:${N3O_GIT_TOKEN}@github.com/".insteadOf "https://github.com/"
+        fi

--- a/.github/workflows/n3o-dotnet-update-nuget.yml
+++ b/.github/workflows/n3o-dotnet-update-nuget.yml
@@ -13,14 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: app token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.N3O_APP_ID }}
-          private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
-          owner: n3oltd
-
       - name: setup-dotnet
         uses: actions/setup-dotnet@v5
         with:
@@ -32,11 +24,15 @@ jobs:
           access-token: ${{ secrets.GH_PAT }}
 
       - name: configure git identity
+        id: git
         uses: n3oltd/actions/.github/actions/n3o-git-identity@main
+        with:
+          app-id: ${{ secrets.N3O_APP_ID }}
+          private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
 
       - name: upgrade
         env:
-          GH_PAT: ${{ steps.app-token.outputs.token }}
+          GH_PAT: ${{ steps.git.outputs.token }}
           AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
Extends the `n3o-git-identity` action so it owns **all** git setup for automation commits, instead of every workflow repeating it.

When given the n3o-babar App credentials, the action now:
1. mints an n3o-babar App installation token (`actions/create-github-app-token`),
2. sets the canonical Babar identity, and
3. configures authenticated `github.com` pushes (`url.insteadOf`) — so the resulting commits are **verified** and properly attributed.

It also exposes the token as an output for steps that still need it as `GH_PAT`. Credentials are optional: callers that omit them get identity-only behaviour (unchanged), so existing callers (`work`, generate-clients) keep working.

```yaml
- uses: n3oltd/actions/.github/actions/n3o-git-identity@main
  with:
    app-id: ${{ secrets.N3O_APP_ID }}
    private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
```

Also refactors `n3o-dotnet-update-nuget` to consume the action's token output, dropping its standalone `app token` step.

**Merge this before** the companion `deployments` / `devops` PRs (they rely on the new `app-id`/`private-key` inputs).