### PR TITLE
Document reusable workflows and inputs

### DIFF
--- a/.github/actions/n3o-sentry-release/action.yml
+++ b/.github/actions/n3o-sentry-release/action.yml
@@ -1,17 +1,23 @@
 name: 'N3O Sentry release'
+description: creates a Sentry release for the n3oltd org and optionally uploads sourcemaps
 
 inputs:
   project:
+    description: Sentry project slug
     required: true
   release:
+    description: release version/identifier to create
     required: true
   environment:
+    description: Sentry environment name to associate the release with
     required: false
     default: ''
   sourcemaps:
+    description: path to the sourcemaps to upload
     required: false
     default: ''
   auth-token:
+    description: Sentry auth token
     required: true
 
 runs:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,30 +1,39 @@
+# Builds and pushes a date-versioned Docker image to N3O's ACR, fetching
+# the Dockerfile from the actions repo and optionally creating a Sentry
+# release with sourcemaps.
 name: 'docker-build-push'
 
 on:
   workflow_call:
     inputs:
       build-args:
+        description: docker build arguments
         type: string
         required: false
-    
+
       container-repository:
+        description: container registry repository to push the image to
         type: string
         required: true
 
       dockerfile:
+        description: path to the Dockerfile
         type: string
         required: true
 
       working-directory:
+        description: directory (relative to the repo root) to run the build/commands in
         type: string
         default: src
 
       sentry-project:
+        description: Sentry project slug for the release and sourcemaps (empty to skip Sentry)
         type: string
         required: false
         default: ''
 
       sentry-sourcemaps:
+        description: whether to extract and upload sourcemaps to Sentry
         type: string
         required: false
         default: ''

--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -1,39 +1,49 @@
+# Builds, optionally tests and packs a .NET project, pushes any NuGet
+# packages to the configured feed, and optionally creates a Sentry release.
 name: 'dotnet-build-pack-push'
 
 on:
   workflow_call:
     inputs:
       runs-on:
+        description: runner label the job executes on
         type: string
         default: ubuntu-latest
 
       dotnet-version:
+        description: .NET SDK version to set up
         type: string
         default: 10.x
 
       working-directory:
+        description: directory (relative to the repo root) to run the build/commands in
         type: string
         default: src
 
       build-configuration:
+        description: build configuration (e.g. Release)
         type: string
         default: Release
 
       run-tests:
+        description: whether to run tests
         type: boolean
         default: false
 
       run-pack:
+        description: whether to create NuGet packages
         type: boolean
         default: false
 
       version-strategy:
+        description: how the version is derived ('tag' from git tag, 'date' for date-based)
         type: string
         default: tag
         # 'tag': version from git tag (refs/tags/v*), fallback 1.0.0
         # 'date': date-based version (YYYY.M.D.run_number)
 
       version:
+        description: explicit version to use; overrides version-strategy when set
         type: string
         default: ''
         # If set, takes precedence over version-strategy. Use when the caller
@@ -41,14 +51,17 @@ on:
         # from a branch rather than a tag).
 
       nuget-source:
+        description: NuGet feed to push packages to
         type: string
         default: 'https://api.nuget.org/v3/index.json'
 
       version-suffix:
+        description: optional prerelease suffix appended to the version
         type: string
         default: ''
 
       sentry-project:
+        description: Sentry project slug for the release and sourcemaps (empty to skip Sentry)
         type: string
         required: false
         default: ''

--- a/.github/workflows/n3o-aks-deploy-postgres.yml
+++ b/.github/workflows/n3o-aks-deploy-postgres.yml
@@ -1,9 +1,13 @@
+# Deploys the Postgres stack to an AKS cluster for a given data region.
+# Decrypts the Postgres secrets and applies the versioned manifests from the region's postgres folder.
+# Called to provision or update the shared Postgres database in a region.
 name: Deploy Postgres to AKS
 
 on:
   workflow_call:
     inputs:
       data-region:
+        description: data residency region the deployment targets (e.g. eu1)
         type: string
         required: true
 

--- a/.github/workflows/n3o-aks-deployment.yml
+++ b/.github/workflows/n3o-aks-deployment.yml
@@ -1,26 +1,34 @@
+# Deploys an N3O service to an AKS cluster by applying the latest versioned manifests from a deployment folder.
+# Resolves the deployment version from metadata.json, applies the YAML to the target namespace, and optionally creates a Sentry release.
+# Called to roll out or update a backend service in a region.
 name: 'Deploy N3O services to AKS'
 
 on:
   workflow_call:
     inputs:
       data-region:
+        description: data residency region the deployment targets (e.g. eu1)
         type: string
         required: true
-        
+
       namespace:
+        description: Kubernetes namespace to deploy into
         type: string
         required: true
 
       deployment-folder:
+        description: path to the deployment folder to apply
         type: string
         required: true
 
       sentry-project:
+        description: Sentry project slug for the release and sourcemaps (empty to skip Sentry)
         type: string
         required: false
         default: ''
 
       sentry-environment:
+        description: Sentry environment name for the release (empty to skip)
         type: string
         required: false
         default: ''

--- a/.github/workflows/n3o-auto-triage-issues.yml
+++ b/.github/workflows/n3o-auto-triage-issues.yml
@@ -1,3 +1,6 @@
+# Reusable workflow that auto-labels newly opened issues that have no labels,
+# applying a configurable triage label via a GitHub App token.
+# Call it from a repo's issue-opened workflow to flag untriaged issues.
 name: n3o auto-triage new issue
 
 on:

--- a/.github/workflows/n3o-docker-build-push-pgbouncer.yml
+++ b/.github/workflows/n3o-docker-build-push-pgbouncer.yml
@@ -1,4 +1,7 @@
-﻿name: 'docker-build-push-pgbouncer'
+﻿# Builds and pushes the N3O PgBouncer Docker image to ACR with date and
+# latest tags, fetching the Dockerfile from the actions repo. Takes no
+# inputs.
+name: 'docker-build-push-pgbouncer'
 
 on:
   workflow_call:

--- a/.github/workflows/n3o-docker-build-push-postgres.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres.yml
@@ -1,4 +1,7 @@
-﻿name: 'docker-build-push-postgres'
+﻿# Builds and pushes the N3O Postgres Docker image to ACR with date and
+# latest tags, fetching the Dockerfile from the actions repo. Takes no
+# inputs.
+name: 'docker-build-push-postgres'
 
 on:
   workflow_call:

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -1,42 +1,53 @@
-﻿name: 'docker-build-push'
+﻿# Builds and pushes an N3O service Docker image to ACR with date/latest/sha
+# tags, skipping the build if an image for the commit already exists, and
+# optionally extracts sourcemaps and creates a Sentry release.
+name: 'docker-build-push'
 
 on:
   workflow_call:
     inputs:
       branch:
+        description: git branch to build from
         type: string
         required: false
         default: 'main'
 
       build-args:
+        description: docker build arguments
         type: string
         required: false
         default: ''
 
       container-repository:
+        description: container registry repository to push the image to
         type: string
         required: true
 
       dockerfile:
+        description: path to the Dockerfile
         type: string
         required: true
 
       context:
+        description: docker build context path
         type: string
         required: false
         default: './src'
 
       secrets:
+        description: docker build secrets passed to the build
         type: string
         required: false
         default: ''
 
       sentry-project:
+        description: Sentry project slug for the release and sourcemaps (empty to skip Sentry)
         type: string
         required: false
         default: ''
 
       sentry-extract-sourcemaps:
+        description: whether to extract and upload sourcemaps to Sentry
         type: boolean
         required: false
         default: false

--- a/.github/workflows/n3o-dotnet-build-pack-push.yml
+++ b/.github/workflows/n3o-dotnet-build-pack-push.yml
@@ -1,4 +1,7 @@
-﻿name: dotnet build, pack and push
+﻿# Reusable workflow that builds .NET projects, packs the listed NuGet packages and
+# pushes them to the feed, optionally publishing generated npm client packages too.
+# Use it as the main CI/CD pipeline for releasing a repo's NuGet (and npm) artifacts.
+name: dotnet build, pack and push
 
 on:
   workflow_call:
@@ -24,10 +27,12 @@ on:
         default: false
 
       version-suffix:
+        description: optional prerelease suffix appended to the version
         type: string
         default: ''
 
       working-directory:
+        description: directory (relative to the repo root) to run the build/commands in
         type: string
         default: src
         

--- a/.github/workflows/n3o-dotnet-build.yml
+++ b/.github/workflows/n3o-dotnet-build.yml
@@ -1,4 +1,6 @@
-﻿name: 'dotnet build'
+﻿# Reusable workflow that checks out the repo and runs a .NET restore and build.
+# Use it for CI on repos that only need to verify the solution compiles.
+name: 'dotnet build'
 
 on:
   workflow_call:
@@ -9,6 +11,7 @@ on:
         default: Release
       
       working-directory:
+        description: directory (relative to the repo root) to run the build/commands in
         type: string
         default: src
 

--- a/.github/workflows/n3o-dotnet-generate-clients.yml
+++ b/.github/workflows/n3o-dotnet-generate-clients.yml
@@ -1,9 +1,13 @@
+# Reusable workflow that builds the solution, runs the n3o CLI to regenerate API
+# clients, and commits any changes back to the repo. Use it to keep generated
+# clients in sync on push (skipped when the commit message has [no-generate-clients]).
 name: dotnet generate clients
 
 on:
   workflow_call:
     inputs:
       working-directory:
+        description: directory (relative to the repo root) to run the build/commands in
         type: string
         default: src
 

--- a/.github/workflows/n3o-dotnet-update-nuget.yml
+++ b/.github/workflows/n3o-dotnet-update-nuget.yml
@@ -1,3 +1,6 @@
+# Reusable workflow that runs the n3o CLI to upgrade our own NuGet packages to their
+# latest versions across the org (or a single repo) and commits the changes upstream.
+# Use it to roll out internal package updates automatically.
 name: 'dotnet-update-nuget'
 
 on:

--- a/.github/workflows/n3o-mobile-app-deploy.yml
+++ b/.github/workflows/n3o-mobile-app-deploy.yml
@@ -1,13 +1,18 @@
+# Deploys a mobile app over-the-air update by pointing a Capgo channel at the latest bundle.
+# Reads the bundle name from metadata and sets the environment's Capgo channel to it.
+# Use to promote a mobile-app bundle to a given environment.
 name: 'Deploy Mobile App'
 
 on:
   workflow_call:
     inputs:
       app-id:
+        description: mobile app identifier (under mobile-apps/)
         type: string
         required: true
-      
+
       environment-id:
+        description: target environment/slot identifier under the deployment path
         type: string
         required: true
 

--- a/.github/workflows/n3o-platforms-app-build-capgo.yml
+++ b/.github/workflows/n3o-platforms-app-build-capgo.yml
@@ -1,9 +1,13 @@
+# Builds the Platforms app JS bundle for a subscription and uploads it to Capgo
+# for over-the-air live updates. Call this to ship a web/JS-only update without
+# rebuilding the native app.
 name: "Build & Push Platforms App"
 
 on:
   workflow_call:
     inputs:
       subscription-code:
+        description: platforms subscription code identifying the charity/tenant
         type: string
         required: true
 

--- a/.github/workflows/n3o-platforms-app-build-native.yml
+++ b/.github/workflows/n3o-platforms-app-build-native.yml
@@ -1,12 +1,17 @@
+# Builds and publishes the native Platforms app (iOS .ipa or Android .apk) for a
+# subscription, syncing Capacitor assets and signing/uploading to the store. Call
+# this to produce a full native app build for a given platform.
 name: Build Platforms App Native
 
 on:
   workflow_call:
     inputs:
       subscription-code:
+        description: platforms subscription code identifying the charity/tenant
         type: string
         required: true
       platform:
+        description: target build platform (ios or android)
         type: string
         required: true
 

--- a/.github/workflows/n3o-platforms-js-build-push.yml
+++ b/.github/workflows/n3o-platforms-js-build-push.yml
@@ -1,13 +1,18 @@
+# Builds the n3o-elements library for a subscription and publishes it as a
+# versioned npm package to GitHub Packages, optionally creating a Sentry release
+# with sourcemaps. Call this to publish the Platforms JS package for a tenant.
 name: 'Build & Push Platforms JS'
 
 on:
   workflow_call:
     inputs:
       subscription-code:
+        description: platforms subscription code identifying the charity/tenant
         type: string
         required: true
 
       sentry-project:
+        description: Sentry project slug for the release and sourcemaps (empty to skip Sentry)
         type: string
         required: false
         default: ''

--- a/.github/workflows/n3o-platforms-js-deploy.yml
+++ b/.github/workflows/n3o-platforms-js-deploy.yml
@@ -1,17 +1,23 @@
+# Deploys the platforms-js package for a charity to its Azure blob storage container.
+# Installs the published @n3oltd/platforms-js-<subscription> package, swaps in the
+# environment config, and replaces the platforms-js/ blobs in the connect-<subscription> container.
 name: 'Deploy Platforms JS'
 
 on:
   workflow_call:
     inputs:
       data-region:
+        description: data residency region the deployment targets (e.g. eu1)
         type: string
         required: true
 
       subscription-code:
+        description: platforms subscription code identifying the charity/tenant
         type: string
         required: true
-      
+
       environment-id:
+        description: target environment/slot identifier under the deployment path
         type: string
         required: true
 

--- a/.github/workflows/n3o-platforms-pages-build.yml
+++ b/.github/workflows/n3o-platforms-pages-build.yml
@@ -1,3 +1,5 @@
+# Installs dependencies and builds the platforms-pages app via Turbo. Call this
+# to produce a build of the Platforms marketing/content pages bundle.
 name: Build Platforms Pages
 
 on:

--- a/.github/workflows/n3o-platforms-pages-deploy.yml
+++ b/.github/workflows/n3o-platforms-pages-deploy.yml
@@ -1,13 +1,18 @@
+# Deploys the platforms-pages release to AKS by applying its Kubernetes YAML manifests.
+# Reads the latest deployment version from metadata, sets up kubectl, then applies the
+# manifests for that version. Use to roll out platforms-pages to a cluster.
 name: Deploy Platforms Pages
 
 on:
   workflow_call:
     inputs:
       data-region:
+        description: data residency region the deployment targets (e.g. eu1)
         type: string
         required: true
 
       environment-id:
+        description: target environment/slot identifier under the deployment path
         type: string
         required: true
 

--- a/.github/workflows/n3o-platforms-playground-build-deploy.yml
+++ b/.github/workflows/n3o-platforms-playground-build-deploy.yml
@@ -1,3 +1,6 @@
+# Builds the platforms-playground app and deploys its JS output to the
+# platforms-playground Azure blob storage container. Call this to publish an
+# updated Playground build.
 name: 'Build & Deploy Platforms Playground'
 
 on:

--- a/.github/workflows/n3o-react-build.yml
+++ b/.github/workflows/n3o-react-build.yml
@@ -1,4 +1,7 @@
-﻿name: react app build and publish
+﻿# Builds and publishes a Create React App project on the self-hosted React-App-Runner.
+# Sets up Node, configures the GitHub npm registry, installs dependencies with sourcemaps
+# and Sentry, then runs the production build. Called by React app repos to build releases.
+name: react app build and publish
 
 on:
   workflow_call:

--- a/.github/workflows/n3o-sites-deploy.yml
+++ b/.github/workflows/n3o-sites-deploy.yml
@@ -1,22 +1,29 @@
+# Deploys a single N3O site to an AKS cluster by applying the latest versioned manifests for that site.
+# Resolves the deployment version from metadata.json under the region's sites/<site-id> folder and optionally creates a Sentry release.
+# Called to roll out or update an individual site in a region.
 name: Deploy N3O Site
 
 on:
   workflow_call:
     inputs:
       data-region:
+        description: data residency region the deployment targets (e.g. eu1)
         type: string
         required: true
-      
+
       site-id:
+        description: identifier of the site to deploy
         type: string
         required: true
 
       sentry-project:
+        description: Sentry project slug for the release and sourcemaps (empty to skip Sentry)
         type: string
         required: false
         default: ''
 
       sentry-environment:
+        description: Sentry environment name for the release (empty to skip)
         type: string
         required: false
         default: ''

--- a/.github/workflows/n3o-vite-ci.yml
+++ b/.github/workflows/n3o-vite-ci.yml
@@ -1,9 +1,12 @@
+# Runs CI for a Vite project: typecheck, lint, optional tests, and a production build.
+# Sets up Node with npm caching and installs via npm ci. Called by Vite app repos on push/PR.
 name: 'vite ci'
 
 on:
   workflow_call:
     inputs:
       node-version:
+        description: Node.js version to set up
         type: string
         default: '24'
 

--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -1,3 +1,7 @@
+# Reusable workflow that syncs PR and push activity to issues in the n3oltd/work repo.
+# Dispatches PR/commit references to the n3o CLI, tracks rollouts, and (for ship-on-merge
+# repos) releases referenced work issues to prod on merge or default-branch push.
+# Call it from a repo's PR/push workflow to keep work-tracking in sync with code changes.
 name: 'n3o-work-dispatch'
 
 on:

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,9 +1,13 @@
-﻿name: Publish NPM package to GitHub Packages
+﻿# Reusable workflow that builds and publishes an npm package to GitHub Packages.
+# Installs deps, builds, stamps a date-based version, then runs npm publish against npm.pkg.github.com.
+# Call it from a release workflow when shipping a package to the org's GitHub Packages registry.
+name: Publish NPM package to GitHub Packages
 
 on:
   workflow_call:
     inputs:
       working-directory:
+        description: directory (relative to the repo root) to run the build/commands in
         type: string
         default: src
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,17 +1,23 @@
+# Reusable workflow that publishes an npm package to the public npmjs.org registry.
+# Optionally builds (prepack) the package, sets the version, then runs npm publish.
+# Call it from a release workflow when shipping a public package to npm.
 name: 'npm-publish'
 
 on:
   workflow_call:
     inputs:
       working-directory:
+        description: directory (relative to the repo root) to run the build/commands in
         type: string
         required: true
 
       version:
+        description: explicit version to use; overrides version-strategy when set
         type: string
         required: true
 
       prepack:
+        description: whether to run the prepack step before publishing
         type: boolean
         default: false
 

--- a/.github/workflows/oauth-static-site-deploy.yml
+++ b/.github/workflows/oauth-static-site-deploy.yml
@@ -1,29 +1,38 @@
+# Configures and restarts an Azure Web App running the OAuth2 Proxy in front of a static site.
+# Points the app at a Docker image and sets the OAuth2 Proxy app settings for Azure AD sign-in, then restarts the app.
+# Called to deploy or update an OAuth-protected static site on Azure.
 name: 'oauth-static-site-deploy'
 
 on:
   workflow_call:
     inputs:
       client-id:
+        description: OAuth client id
         type: string
         required: true
 
       docker-image:
+        description: docker image to deploy
         type: string
         required: true
 
       email-domains:
+        description: allowed email domains for OAuth access
         type: string
         required: true
 
       resource-group:
+        description: Azure resource group
         type: string
         required: true
 
       site-name:
+        description: site name
         type: string
         required: true
 
       tenant-id:
+        description: Azure tenant id
         type: string
         required: true
 

--- a/.github/workflows/publish-karakoram-content.yml
+++ b/.github/workflows/publish-karakoram-content.yml
@@ -1,3 +1,6 @@
+# Reusable workflow that converts Karakoram content YAML to JSON, then publishes it
+# and its image assets to the Azure blob storage containers (global and per-env).
+# Use it to deploy updated Karakoram welcome/featured/getting-started content.
 name: Publish Karakoram Content
 
 on:

--- a/.github/workflows/umbraco-deploy.yml
+++ b/.github/workflows/umbraco-deploy.yml
@@ -1,65 +1,83 @@
+# Configures and restarts an Azure Web App running an Umbraco CMS site.
+# Sets the Docker image, database connection strings, localization, storage, Sentry and Umbraco license app settings, then restarts the app.
+# Called to deploy or update an Umbraco site on Azure.
 name: 'umbraco-deploy'
 
 on:
   workflow_call:
     inputs:
       docker-image:
+        description: docker image to deploy
         type: string
         required: true
 
       resource-group:
+        description: Azure resource group
         type: string
         required: true
 
       environment-id:
+        description: target environment/slot identifier under the deployment path
         type: string
         required: true
 
       site-name:
+        description: site name
         type: string
         required: true
 
       storage-container:
+        description: Azure storage container name
         type: string
         default: 'umbraco'
 
       localization-date-format:
+        description: localized date format for the site
         type: string
         default: dmy_slashes
 
       localization-language:
+        description: localization language for the site
         type: string
         default: en
 
       localization-number-format:
+        description: localized number format for the site
         type: string
         default: international
 
       localization-time-format:
+        description: localized time format for the site
         type: string
         default: '24'
 
       localization-timezone:
+        description: timezone for the site
         type: string
         default: 'Etc/UTC'
 
       site-language-tag:
+        description: localization tag for the site language
         type: string
         required: true
 
       site-name-tag:
+        description: localization tag for the site name
         type: string
         required: true
-        
+
       sentry-dsn:
+        description: Sentry DSN for the deployed app
         type: string
         default: "none"
-        
+
       umbraco-forms-license:
+        description: Umbraco Forms license key
         type: string
         default: "none"
 
       umbraco-engage-license:
+        description: Umbraco Engage license key
         type: string
         default: "none"
     

--- a/.github/workflows/work-dispatch.yml
+++ b/.github/workflows/work-dispatch.yml
@@ -1,3 +1,6 @@
+# Triggered workflow that runs on PR events and pushes in this repo, calling the
+# reusable n3o-work-dispatch workflow with ship-on-merge enabled to keep n3oltd/work
+# issues in sync and release them to prod on merge.
 name: Dispatch PR status to n3oltd/work
 
 on:


### PR DESCRIPTION
Adds documentation that was missing across the actions repo:

- **Per-input descriptions** on every `workflow_call` input that lacked one (~55 inputs across the reusable workflows). These render in the GitHub 'Run workflow' UI and in callers' editors.
- **A top-level comment block** on all 30 workflow files summarizing what each does and when to call it (GitHub workflows have no native description field, so these are leading `#` comments).
- **`n3o-sentry-release` action**: added the missing top-level `description` plus descriptions for all five inputs.

Recurring inputs (`data-region`, `working-directory`, `sentry-project`, `subscription-code`, `environment-id`, etc.) use consistent wording throughout.

Additions only — no workflow logic, input names, defaults, or step behaviour changed. All 31 files validated with `yaml.safe_load`.