### PR TITLE
Declare playground build inputs

### DIFF
--- a/.github/workflows/n3o-platforms-playground-build-deploy.yml
+++ b/.github/workflows/n3o-platforms-playground-build-deploy.yml
@@ -5,6 +5,17 @@ name: 'Build & Deploy Platforms Playground'
 
 on:
   workflow_call:
+    inputs:
+      subscription-code:
+        description: platforms subscription code identifying the charity/tenant
+        type: string
+        required: false
+        default: ''
+      environment:
+        description: environment name passed to the playground build as VITE_ENVIRONMENT
+        type: string
+        required: false
+        default: ''
 
 env:
   GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
`n3o-platforms-playground-build-deploy.yml` references `inputs.subscription-code` and `inputs.environment` (as `VITE_SUBSCRIPTION_CODE` / `VITE_ENVIRONMENT`) but declared no `workflow_call` inputs, so they were always empty at build time. Declares both as documented optional inputs (default `''`) — fixes the undeclared-input bug with zero runtime change.

Note: the only caller (`fe-platforms/platforms-playground-ci.yml`) passes nothing, so the build still gets empty values. If the playground should build with specific values, they can now be passed in (or defaulted) — flagged for follow-up.