### PR TITLE
feat: add n3o-dotnet-cli-setup action and adopt it in workflows

### DIFF
--- a/.github/actions/n3o-dotnet-cli-setup/action.yml
+++ b/.github/actions/n3o-dotnet-cli-setup/action.yml
@@ -1,0 +1,40 @@
+name: n3o dotnet + cli setup
+description: >
+  Sets up the .NET SDK and installs the n3o CLI in one step. Bundles actions/setup-dotnet
+  followed by n3o-cli-install (which the CLI's dotnet tool install requires). Azure inputs
+  are optional for callers that only need the nuget source token.
+
+inputs:
+  access-token:
+    description: Access token for the nuget source
+    required: true
+  azure-client-id:
+    description: Azure client id for key vault access
+    required: false
+    default: ''
+  azure-client-secret:
+    description: Azure client secret for key vault access
+    required: false
+    default: ''
+  azure-tenant-id:
+    description: Azure tenant id for key vault access
+    required: false
+    default: ''
+  dotnet-version:
+    description: .NET SDK version to install
+    required: false
+    default: '10.x'
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+
+    - uses: n3oltd/actions/.github/actions/n3o-cli-install@main
+      with:
+        access-token: ${{ inputs.access-token }}
+        azure-client-id: ${{ inputs.azure-client-id }}
+        azure-client-secret: ${{ inputs.azure-client-secret }}
+        azure-tenant-id: ${{ inputs.azure-tenant-id }}

--- a/.github/workflows/n3o-aks-deploy-postgres.yml
+++ b/.github/workflows/n3o-aks-deploy-postgres.yml
@@ -23,11 +23,6 @@ jobs:
           sparse-checkout: |
             ${{ inputs.data-region }}/postgres
       
-      - name: setup-dotnet
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.x'
-
       - id: get-deployment-version
         name: Get Deployment Version
         working-directory: ${{ inputs.data-region }}/postgres/latest
@@ -42,8 +37,8 @@ jobs:
           secretName=$(jq -r '.secretName' metadata.json)
           echo "secretName=$secretName" >> $GITHUB_OUTPUT 
           
-      - name: install n3o cli
-        uses: n3oltd/actions/.github/actions/n3o-cli-install@main
+      - name: setup dotnet + n3o cli
+        uses: n3oltd/actions/.github/actions/n3o-dotnet-cli-setup@main
         with:
           access-token: ${{ secrets.GH_PAT }}
           

--- a/.github/workflows/n3o-dotnet-build-pack-push.yml
+++ b/.github/workflows/n3o-dotnet-build-pack-push.yml
@@ -50,19 +50,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v6
 
-      - name: setup-dotnet
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.x'
-
       - name: setup-node
         if: inputs.npm-packages != ''
         uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      - name: install n3o cli
-        uses: n3oltd/actions/.github/actions/n3o-cli-install@main
+      - name: setup dotnet + n3o cli
+        uses: n3oltd/actions/.github/actions/n3o-dotnet-cli-setup@main
         with:
           access-token: ${{ env.GH_PAT }}
 

--- a/.github/workflows/n3o-dotnet-generate-clients.yml
+++ b/.github/workflows/n3o-dotnet-generate-clients.yml
@@ -38,18 +38,13 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: setup-dotnet
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.x'
-
       - name: setup-node
         uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      - name: install n3o cli
-        uses: n3oltd/actions/.github/actions/n3o-cli-install@main
+      - name: setup dotnet + n3o cli
+        uses: n3oltd/actions/.github/actions/n3o-dotnet-cli-setup@main
         with:
           access-token: ${{ secrets.GH_PAT }}
           azure-client-id: ${{ env.AZURE_CLIENT_ID }}

--- a/.github/workflows/n3o-dotnet-update-nuget.yml
+++ b/.github/workflows/n3o-dotnet-update-nuget.yml
@@ -16,13 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: setup-dotnet
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.x'
-
-      - name: install n3o cli
-        uses: n3oltd/actions/.github/actions/n3o-cli-install@main
+      - name: setup dotnet + n3o cli
+        uses: n3oltd/actions/.github/actions/n3o-dotnet-cli-setup@main
         with:
           access-token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -34,13 +34,8 @@ jobs:
           private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
           owner: n3oltd
 
-      - name: setup-dotnet
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.x'
-
-      - name: install n3o cli
-        uses: n3oltd/actions/.github/actions/n3o-cli-install@main
+      - name: setup dotnet + n3o cli
+        uses: n3oltd/actions/.github/actions/n3o-dotnet-cli-setup@main
         with:
           access-token: ${{ secrets.GH_PAT }}
           azure-client-id: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
@@ -131,13 +126,8 @@ jobs:
           private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
           owner: n3oltd
 
-      - name: setup-dotnet
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.x'
-
-      - name: install n3o cli
-        uses: n3oltd/actions/.github/actions/n3o-cli-install@main
+      - name: setup dotnet + n3o cli
+        uses: n3oltd/actions/.github/actions/n3o-dotnet-cli-setup@main
         with:
           access-token: ${{ secrets.GH_PAT }}
           azure-client-id: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}


### PR DESCRIPTION
## What

Adds a `n3o-dotnet-cli-setup` composite action that bundles `actions/setup-dotnet` + `n3o-cli-install` (the CLI's `dotnet tool install` requires the SDK), and adopts it across this repo's reusable workflows. This collapses a block that was repeated identically in 32 workflow files across `work`, `actions`, `devops` and `deployments`.

### Action inputs
- `access-token` (required) — nuget source token
- `azure-client-id` / `azure-client-secret` / `azure-tenant-id` (optional) — for callers that need key vault access; omitted for token-only callers
- `dotnet-version` (optional, default `'10.x'`)

## Workflows adopted here

- `n3o-work-dispatch` (both jobs)
- `n3o-dotnet-update-nuget`
- `n3o-dotnet-build-pack-push` — `setup-node` now precedes the bundle (independent step, order-safe)
- `n3o-dotnet-generate-clients` — same (`setup-node` precedes; azure passed from `env`)
- `n3o-aks-deploy-postgres` — the two `jq` metadata-read steps now precede the bundle (they need neither dotnet nor the CLI)

The only hard ordering constraint — setup-dotnet before cli-install — is preserved inside the action. Interleaved steps (node, metadata reads) are independent and simply run before the bundle.

## Companion PRs (use this action `@main`, so merge this first)
- n3oltd/work — 22 workflows
- n3oltd/devops — 4 workflows
- n3oltd/deployments — eu1-nightlies

## Validation
- `yaml.safe_load` passes on the action and all edited workflows.
- No `n3o-cli-install@main` references remain in this repo's workflows.
