### PR TITLE
ci: force n3o-docker-build-push onto the self-hosted fleet

### DIFF
--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -58,9 +58,14 @@ env:
 
 jobs:
   job1:
-    name: ubuntu-latest
+    name: build-push
 
-    runs-on: ubuntu-latest
+    # Forced to the self-hosted fleet (no hosted fallback) so these container builds
+    # never burn paid GitHub minutes — they're dispatch-triggered (nightlies/deploys),
+    # not PR gates, so queueing when the fleet is busy is fine. `docker build`/buildx
+    # use the fleet's Docker-in-Docker sidecar via DOCKER_HOST. All caller repos are
+    # private, so the private runner group is reachable without a public-repo carve-out.
+    runs-on: n3o-github-runner
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -60,11 +60,8 @@ jobs:
   job1:
     name: build-push
 
-    # Forced to the self-hosted fleet (no hosted fallback) so these container builds
-    # never burn paid GitHub minutes — they're dispatch-triggered (nightlies/deploys),
-    # not PR gates, so queueing when the fleet is busy is fine. `docker build`/buildx
-    # use the fleet's Docker-in-Docker sidecar via DOCKER_HOST. All caller repos are
-    # private, so the private runner group is reachable without a public-repo carve-out.
+    # Self-hosted only (no hosted fallback) so these builds don't consume paid GitHub
+    # minutes; queueing when the fleet is busy is acceptable.
     runs-on: n3o-github-runner
 
     steps:


### PR DESCRIPTION
Changes `n3o-docker-build-push.yml` from `runs-on: ubuntu-latest` to **`runs-on: n3o-github-runner`** — self-hosted only, **no hosted fallback**.

## Why
These are the container image builds the EU1 nightlies (and deploys) fire off via `gh workflow run build-container.yml` — **workflow_dispatch-triggered, not PR gates** — and they're where most of the paid build minutes go. Forcing them self-hosted stops the bleed; queueing on the fleet when busy is fine (nightlies can wait).

FAST (pick-runner) would **not** achieve this — 65 nightly builds vs 8 runners means most would spill to paid hosted. Self-hosted-only is the right lever.

## Safety checks done
- **All 58 caller repos are private** → the private runner group is reachable; no public-repo carve-out needed.
- `build-container.yml` is **workflow_dispatch-only** in every caller (one repo, `svc-fe-work`, also builds on push) → moving this does **not** slow PR checks.
- `docker build`/buildx run against the fleet's **DinD sidecar** via `DOCKER_HOST` (baked into the runner image + deployment).

## 🚩 Verify on first run
buildx-over-DinD — `docker/setup-buildx-action` + `docker/build-push-action` should work against the sidecar daemon, but worth watching the first nightly/dispatch build.

## Not included (flag if you want them too)
- Legacy `docker-build-push.yml` (25 callers: sites, headless, fe-platforms…)
- `n3o-docker-build-push-pgbouncer.yml` / `-postgres.yml` (infra images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)