### PR TITLE
ci: run babar on the self-hosted fleet (private repos), hosted for public

### DIFF
--- a/.github/workflows/n3o-babar.yml
+++ b/.github/workflows/n3o-babar.yml
@@ -23,7 +23,10 @@ jobs:
     if: >-
       ${{ startsWith(github.event.comment.body, '/babar ')
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
-    runs-on: ubuntu-latest
+    # Private repos run on the self-hosted fleet (queue if busy — babar can wait, no paid
+    # minutes); public-repo callers fall back to hosted since the fleet's runner group is
+    # private-repo only.
+    runs-on: ${{ github.event.repository.private && 'n3o-github-runner' || 'ubuntu-latest' }}
     timeout-minutes: 45
     env:
       AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}


### PR DESCRIPTION
Flips `n3o-babar.yml` (the reusable workflow behind `/babar`, ~235 callers) off `ubuntu-latest`:

```yaml
runs-on: ${{ github.event.repository.private && 'n3o-github-runner' || 'ubuntu-latest' }}
```

- **Private repos** → the self-hosted fleet. babar can wait, so it queues if all runners are busy — **no paid minutes**.
- **Public repos** → `ubuntu-latest` (the fleet's runner group is private-repo only, so public callers can't use it).

## Why inline, not the pick job
Wait-mode is a pure private/public decision — no live-capacity query needed — so a one-line `runs-on` expression does it with **zero extra jobs and zero extra App API calls per `/babar`**. That matters: babar is high-volume and we just cleared an App-rate-limit incident, so I avoided adding any per-invocation token minting. (`n3o-pick-runner` `wait` mode in #95 is for the reusable *build* workflows that route by event; babar doesn't need it.)

## Canary
This is the first real consumer of the fleet for an interactive, org-wide workflow. babar's tooling (.NET, n3o CLI per-run, gh, git, Claude CLI) is all on the fleet, and the `.dotnet` perms fix is live, so a private-repo `/babar` should now run end-to-end. Worth watching the first few.

🤖 Generated with [Claude Code](https://claude.com/claude-code)