### PR TITLE
Explain the guard-linked failure with an actionable error annotation

### DIFF
--- a/.github/workflows/n3o-pick-runner.yml
+++ b/.github/workflows/n3o-pick-runner.yml
@@ -43,12 +43,17 @@ jobs:
     outputs:
       runs-on: ${{ steps.pick.outputs.runs-on }}
     steps:
-      # An App token is needed to list org runners; the default GITHUB_TOKEN can't.
+      # Listing org runners needs an App token (the default GITHUB_TOKEN can't). Use the
+      # dedicated n3o-github-runners App so this stays off the n3o-babar App's rate limit.
+      # Only private repos query the fleet (public repos always fall back to hosted), so
+      # only they mint a token — which also keeps the secret private-repo scoped.
       - id: identity
-        uses: n3oltd/actions/.github/actions/n3o-git-identity@main
+        if: ${{ github.event.repository.private }}
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.N3O_APP_ID }}
-          private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.N3O_GITHUB_RUNNERS_APP_ID }}
+          private-key: ${{ secrets.N3O_GITHUB_RUNNERS_APP_PRIVATE_KEY }}
+          owner: n3oltd
 
       - id: pick
         shell: bash


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2540

## Summary

Follow-up to actions#97 (Layer B of work#2539). Makes the `guard-linked` check self-explanatory.

Previously a failed check showed only the cryptic job name; the *why* and *how-to-fix* were buried one click into the job log, and relied on the CLI's own output reaching CI. Now the step wraps `n3o work guard-linked` and, on failure, emits a GitHub `::error::` annotation:

> This PR isn't linked to a work issue. Add `re n3oltd/work#NNN` to the PR description (a full issue URL also works), or apply the `no-work-issue` label for a genuine non-tracked change.

The annotation renders prominently on the **Checks** tab and the run summary, independent of the CLI's stdout — so a dev sees exactly what to do without opening logs.

## Test plan
- [x] `yaml.safe_load` parses; jobs unchanged (`pr`, `guard-linked`, `push`)