### PR TITLE
feat: n3o-pick-runner uses the dedicated n3o-github-runners App

### DIFF
--- a/.github/workflows/n3o-pick-runner.yml
+++ b/.github/workflows/n3o-pick-runner.yml
@@ -43,10 +43,9 @@ jobs:
     outputs:
       runs-on: ${{ steps.pick.outputs.runs-on }}
     steps:
-      # Listing org runners needs an App token (the default GITHUB_TOKEN can't). Use the
-      # dedicated n3o-github-runners App so this stays off the n3o-babar App's rate limit.
-      # Only private repos query the fleet (public repos always fall back to hosted), so
-      # only they mint a token — which also keeps the secret private-repo scoped.
+      # Listing org runners needs an App token (the default GITHUB_TOKEN can't). Only
+      # private repos query the fleet — public repos always fall back to hosted — so only
+      # they mint a token, which keeps the App secret scoped to private repos.
       - id: identity
         if: ${{ github.event.repository.private }}
         uses: actions/create-github-app-token@v2

--- a/.github/workflows/n3o-pick-runner.yml
+++ b/.github/workflows/n3o-pick-runner.yml
@@ -43,12 +43,17 @@ jobs:
     outputs:
       runs-on: ${{ steps.pick.outputs.runs-on }}
     steps:
-      # An App token is needed to list org runners; the default GITHUB_TOKEN can't.
+      # Listing org runners needs an App token (the default GITHUB_TOKEN can't). Use the
+      # dedicated n3o-github-runners App so this stays off the n3o-babar App's rate limit.
+      # Only private repos query the fleet (public repos always fall back to hosted), so
+      # only they mint a token — which also keeps the secret private-repo scoped.
       - id: identity
-        uses: n3oltd/actions/.github/actions/n3o-git-identity@main
+        if: ${{ github.event.repository.private }}
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.N3O_APP_ID }}
-          private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.N3O_GITHUB_RUNNERS_APP_ID }}
+          private-key: ${{ secrets.N3O_GITHUB_RUNNERS_APP_PRIVATE_KEY }}
+          owner: n3oltd
 
       - id: pick
         shell: bash


### PR DESCRIPTION
Switches `n3o-pick-runner`'s runner-listing token from a shared App to the dedicated **`n3o-github-runners`** App (it has *self-hosted runners: read*, which can list org runners). Keeping the picker on its own App isolates its API usage from other automation, so it scales as more workflows adopt FAST without contending for a shared rate limit.

- Only **private** repos mint the token (public repos always fall back to hosted and never query the fleet), so the org secrets are **private-repo visibility** — never exposed to public-repo Actions.
- Org secrets `N3O_GITHUB_RUNNERS_APP_ID` / `N3O_GITHUB_RUNNERS_APP_PRIVATE_KEY` are already set.

Prerequisite for adopting FAST broadly across the build/deploy workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)