### PR TITLE
ci: force the remaining Docker builders onto the self-hosted fleet

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -50,9 +50,11 @@ on:
 
 jobs:
   job1:
-    name: ubuntu-latest
+    name: build-push
 
-    runs-on: ubuntu-latest
+    # Self-hosted only (no hosted fallback) so these builds don't consume paid GitHub
+    # minutes; queueing when the fleet is busy is acceptable.
+    runs-on: n3o-github-runner
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -52,8 +52,6 @@ jobs:
   job1:
     name: build-push
 
-    # Self-hosted only (no hosted fallback) so these builds don't consume paid GitHub
-    # minutes; queueing when the fleet is busy is acceptable.
     runs-on: n3o-github-runner
 
     steps:

--- a/.github/workflows/n3o-docker-build-push-pgbouncer.yml
+++ b/.github/workflows/n3o-docker-build-push-pgbouncer.yml
@@ -7,9 +7,11 @@ on:
   workflow_call:
 
 jobs:
-  build-push-docker-image-job:    
+  build-push-docker-image-job:
 
-    runs-on: ubuntu-latest
+    # Self-hosted only (no hosted fallback) so these builds don't consume paid GitHub
+    # minutes; queueing when the fleet is busy is acceptable.
+    runs-on: n3o-github-runner
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/n3o-docker-build-push-pgbouncer.yml
+++ b/.github/workflows/n3o-docker-build-push-pgbouncer.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build-push-docker-image-job:
 
-    # Self-hosted only (no hosted fallback) so these builds don't consume paid GitHub
-    # minutes; queueing when the fleet is busy is acceptable.
     runs-on: n3o-github-runner
 
     steps:

--- a/.github/workflows/n3o-docker-build-push-postgres.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres.yml
@@ -7,9 +7,11 @@ on:
   workflow_call:
 
 jobs:
-  build-push-docker-image-job:    
+  build-push-docker-image-job:
 
-    runs-on: ubuntu-latest
+    # Self-hosted only (no hosted fallback) so these builds don't consume paid GitHub
+    # minutes; queueing when the fleet is busy is acceptable.
+    runs-on: n3o-github-runner
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/n3o-docker-build-push-postgres.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build-push-docker-image-job:
 
-    # Self-hosted only (no hosted fallback) so these builds don't consume paid GitHub
-    # minutes; queueing when the fleet is busy is acceptable.
     runs-on: n3o-github-runner
 
     steps:


### PR DESCRIPTION
Same treatment as `n3o-docker-build-push` (already merged) for the rest of the image builders:

- **`docker-build-push.yml`** (legacy, 25 callers — sites, headless, fe-platforms, …)
- **`n3o-docker-build-push-pgbouncer.yml`**, **`n3o-docker-build-push-postgres.yml`** (infra images)

`runs-on: ubuntu-latest` → **`n3o-github-runner`** (self-hosted only). All callers are private, so no public carve-out is needed; `docker build`/buildx use the fleet's DinD sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)