### PR TITLE
ci: route n3o-dotnet-build via n3o-pick-runner (push=fast, PR=wait)

### DIFF
--- a/.github/workflows/n3o-dotnet-build.yml
+++ b/.github/workflows/n3o-dotnet-build.yml
@@ -19,8 +19,15 @@ env:
   GH_PAT: ${{ secrets.GH_PAT }}
 
 jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    with:
+      mode: ${{ github.event_name == 'pull_request' && 'wait' || 'fast' }}
+    secrets: inherit
+
   build:
-    runs-on: ubuntu-latest
+    needs: pick
+    runs-on: ${{ needs.pick.outputs.runs-on }}
 
     defaults:
       run:


### PR DESCRIPTION
**Proof-of-pattern for the FAST/EVENT rollout** — validate this before I replicate across the other build/deploy workflows.

A `pick` job (calling `n3o-pick-runner`) chooses the runner, and `build` runs on its output:
- **push** (main CI) → `fast`: prefer the fleet, 30s wait, then hosted fallback.
- **pull_request** → `wait`: self-hosted only, queue if busy.
- **public repos** → hosted in both (handled inside pick-runner).

### What this validates
- **Nested reusable-workflow secret inheritance**: caller → `n3o-dotnet-build` → `n3o-pick-runner`. The runners-App org secrets reach the pick job via `secrets: inherit` (callers already inherit, same as `GH_PAT`).
- `runs-on: ${{ needs.pick.outputs.runs-on }}` resolves correctly.

### Caveat
Callers that pass secrets *explicitly* (not `secrets: inherit`) wouldn't forward the runners-App secret to the pick job. n3oltd callers use `inherit`, but worth confirming on the first real PR + push build before rolling this to the ~15 other workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)