### PR TITLE
ci: route the deploy workflows via n3o-pick-runner (fast)

### DIFF
--- a/.github/workflows/n3o-aks-deploy-postgres.yml
+++ b/.github/workflows/n3o-aks-deploy-postgres.yml
@@ -12,10 +12,15 @@ on:
         required: true
 
 jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    secrets: inherit
+
   deploy-to-aks:
+    needs: pick
     name: Deploy Postgres to AKS
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.pick.outputs.runs-on }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/n3o-aks-deployment.yml
+++ b/.github/workflows/n3o-aks-deployment.yml
@@ -34,10 +34,15 @@ on:
         default: ''
 
 jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    secrets: inherit
+
   deploy-to-aks:
+    needs: pick
     name: Deploy service to AKS
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.pick.outputs.runs-on }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/n3o-mobile-app-deploy.yml
+++ b/.github/workflows/n3o-mobile-app-deploy.yml
@@ -20,10 +20,15 @@ env:
   GH_PAT: ${{ secrets.GH_PAT }}
 
 jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    secrets: inherit
+
   deploy-platforms:
+    needs: pick
     name: Deploy Mobile App
-    
-    runs-on: ubuntu-latest
+
+    runs-on: ${{ needs.pick.outputs.runs-on }}
     
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/n3o-platforms-js-deploy.yml
+++ b/.github/workflows/n3o-platforms-js-deploy.yml
@@ -25,10 +25,15 @@ env:
   GH_PAT: ${{ secrets.GH_PAT }}
 
 jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    secrets: inherit
+
   deploy-platforms:
+    needs: pick
     name: Deploy Platforms
-    
-    runs-on: ubuntu-latest
+
+    runs-on: ${{ needs.pick.outputs.runs-on }}
     
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/n3o-platforms-pages-deploy.yml
+++ b/.github/workflows/n3o-platforms-pages-deploy.yml
@@ -17,10 +17,15 @@ on:
         required: true
 
 jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    secrets: inherit
+
   deploy-to-aks:
+    needs: pick
     name: Deploy to AKS
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.pick.outputs.runs-on }}
     
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/n3o-sites-deploy.yml
+++ b/.github/workflows/n3o-sites-deploy.yml
@@ -29,10 +29,15 @@ on:
         default: ''
 
 jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    secrets: inherit
+
   deploy-to-aks:
+    needs: pick
     name: Deploy to AKS
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.pick.outputs.runs-on }}
     
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/oauth-static-site-deploy.yml
+++ b/.github/workflows/oauth-static-site-deploy.yml
@@ -47,10 +47,15 @@ on:
         required: true
 
 jobs:
-  job1:
-    name: ubuntu-latest
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    secrets: inherit
 
-    runs-on: ubuntu-latest
+  job1:
+    needs: pick
+    name: deploy
+
+    runs-on: ${{ needs.pick.outputs.runs-on }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/umbraco-deploy.yml
+++ b/.github/workflows/umbraco-deploy.yml
@@ -95,10 +95,15 @@ on:
         required: false
 
 jobs:
-  job1:
-    name: ubuntu-latest
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    secrets: inherit
 
-    runs-on: ubuntu-latest
+  job1:
+    needs: pick
+    name: deploy
+
+    runs-on: ${{ needs.pick.outputs.runs-on }}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Applies the validated pick-runner pattern (proven in #102) to the **8 deploy reusable workflows**:

`n3o-aks-deployment`, `n3o-aks-deploy-postgres`, `n3o-sites-deploy`, `n3o-platforms-pages-deploy`, `n3o-platforms-js-deploy`, `n3o-mobile-app-deploy`, `oauth-static-site-deploy`, `umbraco-deploy`.

Each gains a `pick` job and runs on its output — **fast** mode (default): prefer the self-hosted fleet, fall back to hosted when busy, so deploys are never blocked. The fleet has `kubectl`/`az`/`helm` baked in; public repos fall back to hosted.

Same nested secret-inheritance as the merged `n3o-dotnet-build` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)