### PR TITLE
ci: route n3o-dotnet-build-pack-push via n3o-pick-runner (push=fast, PR=wait)

### DIFF
--- a/.github/workflows/n3o-dotnet-build-pack-push.yml
+++ b/.github/workflows/n3o-dotnet-build-pack-push.yml
@@ -43,8 +43,15 @@ env:
   AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
 
 jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    with:
+      mode: ${{ github.event_name == 'pull_request' && 'wait' || 'fast' }}
+    secrets: inherit
+
   build:
-    runs-on: ubuntu-latest
+    needs: pick
+    runs-on: ${{ needs.pick.outputs.runs-on }}
 
     steps:
       - name: checkout


### PR DESCRIPTION
Applies the validated pick-runner pattern (#102) to the main .NET ship build (`n3o-dotnet-build-pack-push`, ~192 callers).

- **push** (main CI) → `fast`: prefer the fleet, fall back to hosted.
- **PR** → `wait`: self-hosted only.

Verified safe: the workflow declares **no explicit secrets** and its callers use **`secrets: inherit`** (checked cli, cli-babar, lib-be-ai, Karakoram.Connections), so the runners-App secret reaches the pick job — unlike the deploys (#103, closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)