### PR TITLE
perf: cache nuget packages across dotnet builds

### DIFF
--- a/.github/actions/dotnet-restore-build/action.yml
+++ b/.github/actions/dotnet-restore-build/action.yml
@@ -17,6 +17,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: cache nuget packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.lock.json', '**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-
+
     - name: dotnet build
       shell: bash
       working-directory: ${{github.workspace}}/${{ inputs.working-directory }}
@@ -24,4 +32,4 @@ runs:
         GH_USERNAME: n3oltd
         GH_PAT: ${{ inputs.access-token }}
       run: |
-        dotnet build -c "${{inputs.build-configuration}}" 
+        dotnet build -c "${{inputs.build-configuration}}"

--- a/.github/actions/dotnet-restore-build/action.yml
+++ b/.github/actions/dotnet-restore-build/action.yml
@@ -17,7 +17,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Only on GitHub-hosted runners — the self-hosted fleet uses a persistent
+    # shared package cache instead of actions/cache's tarball transfer.
     - name: cache nuget packages
+      if: runner.environment == 'github-hosted'
       uses: actions/cache@v4
       with:
         path: ~/.nuget/packages

--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -109,7 +109,10 @@ jobs:
           fi
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
+      # Only on GitHub-hosted runners — the self-hosted fleet uses a persistent
+      # shared package cache instead of actions/cache's tarball transfer.
       - name: cache nuget packages
+        if: runner.environment == 'github-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages

--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -109,6 +109,14 @@ jobs:
           fi
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: cache nuget packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.lock.json', '**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
       - name: dotnet restore
         run: dotnet restore
 


### PR DESCRIPTION
NuGet package caching for the dotnet builds — **scoped to GitHub-hosted runners only**.

Adds `actions/cache` for `~/.nuget/packages` (keyed on the repo's project files), gated by `if: runner.environment == 'github-hosted'`, in:
- **`dotnet-restore-build`** composite (used by `n3o-dotnet-build` + `n3o-dotnet-build-pack-push` → ~all dotnet repos)
- **legacy `dotnet-build-pack-push.yml`**

### Why hosted-only
On the **self-hosted fleet**, `actions/cache` is a tarball up/download to GitHub's cache service — not the right tool. The fleet will instead use a **persistent shared package cache** (shared volume or pull-through proxy), tracked separately. `actions/cache` is the right fit only for the **hosted fallback** runners (ephemeral, no persistent `~/.nuget/packages`, no shared volume).

**Purge:** automatic — GitHub evicts LRU (10 GB/repo, 7-day). Cache is per-repo (scoped to the caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)