### PR TITLE
Tell headless Claude runs not to pause to ask the user

### DIFF
--- a/.github/actions/n3o-claude-run/action.yml
+++ b/.github/actions/n3o-claude-run/action.yml
@@ -84,6 +84,7 @@ runs:
           --permission-mode "$PERMISSION_MODE"
           --max-turns "$MAX_TURNS"
           --output-format stream-json
+          --append-system-prompt "You are running autonomously in CI with no human available to answer questions. Never pause to ask the user — when a step would otherwise prompt a developer to choose (for example, which work issue to link a PR to), make a reasonable decision yourself and proceed."
           --verbose )
         [ -n "$MCP_CONFIG" ] && args+=( --mcp-config "$MCP_CONFIG" )
         [ -n "$MODEL" ] && args+=( --model "$MODEL" )


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2540

## Summary

Follow-up flagged on agents#25. The dedup guidance says "if a developer is driving interactively, ask which work issue; otherwise search then create" — but a headless `claude -p` run has no human to answer, so the "ask" branch would stall the run.

This appends a system-prompt directive in `n3o-claude-run` (via `claude --append-system-prompt`): *"You are running autonomously in CI with no human available to answer questions. Never pause to ask the user — make a reasonable decision yourself and proceed."*

So the shared prompts / `contexts/fixes.md` stay mode-agnostic, and the runner supplies the one fact they can't carry: that this particular run is non-interactive. Doesn't touch the prompt files.

## Test plan
- [x] `action.yml` parses as YAML; the flag is added to the `claude` args array