### PR TITLE
feat: enforce PR conventions in CI Claude runs

### DIFF
--- a/.github/actions/n3o-claude-run/action.yml
+++ b/.github/actions/n3o-claude-run/action.yml
@@ -41,6 +41,13 @@ inputs:
     description: Directory to run Claude in
     required: false
     default: '.'
+  github-token:
+    description: >
+      Token with read access to the private n3oltd/claude plugin marketplace (e.g. the org-wide
+      GH_PAT). When set, the run loads the n3o-conventions plugin so its PR hook (work-issue +
+      template) applies to any PR the agent opens. Empty skips it — the run proceeds unguarded.
+    required: false
+    default: ''
 
 outputs:
   result:
@@ -63,6 +70,21 @@ runs:
     - name: Install Claude Code
       shell: bash
       run: command -v claude >/dev/null 2>&1 || npm install -g @anthropic-ai/claude-code
+
+    # Best-effort: a transient or unreachable marketplace must not fail the run. The credential
+    # is env-scoped to these git calls so it doesn't repoint the job's git auth (agent pushes).
+    - name: Load n3o conventions
+      if: ${{ inputs.github-token != '' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        export GIT_CONFIG_COUNT=1
+        export GIT_CONFIG_KEY_0="url.https://x-access-token:${GH_TOKEN}@github.com/.insteadOf"
+        export GIT_CONFIG_VALUE_0="https://github.com/"
+        claude plugin marketplace add n3oltd/claude 2>/dev/null \
+          || claude plugin marketplace update n3o-tools 2>/dev/null || true
+        claude plugin install n3o-conventions@n3o-tools --scope user 2>/dev/null || true
 
     - name: Run Claude
       id: run

--- a/.github/workflows/n3o-babar.yml
+++ b/.github/workflows/n3o-babar.yml
@@ -146,3 +146,4 @@ jobs:
           mcp-config: ${{ env.MCP_CONFIG }}
           max-turns: '120'
           max-cost-usd: '5'
+          github-token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2561

## Summary

`n3o-claude-run` runs `claude -p` without loading any plugin, so our `n3o-conventions` PR check wasn't applied when a CI agent opens a PR (e.g. via `/babar`). `claude -p` auto-loads installed plugins and PreToolUse hooks fire non-interactively, so this adds a best-effort step that installs the plugin before the run, plus an optional `github-token` input to read the private marketplace (Babar passes the org-wide `GH_PAT`). The credential is env-scoped so it doesn't repoint the job's git auth used for the agent's own pushes; if the marketplace is unreachable the run proceeds rather than failing.

## Test plan

- [x] `action.yml` and `n3o-babar.yml` parse as valid YAML
- [ ] `/babar` on a private repo installs the plugin and a non-compliant `gh pr create` is held to the convention
- [ ] A run with no `github-token` skips the step and proceeds unguarded
