### PR TITLE
fix: no-work-issue opt-out reads the PR body marker, not a label

### DIFF
--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -119,8 +119,7 @@ jobs:
         env:
           PR_MERGED: ${{ github.event.pull_request.merged }}
           ACTOR: ${{ github.actor }}
-          # Escape hatch for a genuine untracked chore: a `no-work-issue` marker in the PR body
-          # (NOT a label — `no-work-issue` does not exist as a label in code repos).
+          # Escape hatch for a genuine untracked chore: a `no-work-issue` marker in the PR body.
           OPT_OUT: ${{ contains(github.event.pull_request.body, 'no-work-issue') }}
         run: |
           skip=false

--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -119,7 +119,9 @@ jobs:
         env:
           PR_MERGED: ${{ github.event.pull_request.merged }}
           ACTOR: ${{ github.actor }}
-          OPT_OUT: ${{ contains(github.event.pull_request.labels.*.name, 'no-work-issue') }}
+          # Escape hatch for a genuine untracked chore: a `no-work-issue` marker in the PR body
+          # (NOT a label — `no-work-issue` does not exist as a label in code repos).
+          OPT_OUT: ${{ contains(github.event.pull_request.body, 'no-work-issue') }}
         run: |
           skip=false
           if [ "$PR_MERGED" = "true" ] || [ "$OPT_OUT" = "true" ]; then skip=true; fi


### PR DESCRIPTION
re n3oltd/work#2557

## Summary
`n3o-work-dispatch.yml`'s guard-linked exemption checked `github.event.pull_request.labels` for `no-work-issue`. But there is **no `no-work-issue` label** in code repos (`--label no-work-issue` is rejected by GitHub) — the documented escape hatch is a **body marker**: a `no-work-issue` line in the PR body. This flips `OPT_OUT` to read `github.event.pull_request.body`, with a comment making the body-marker semantics explicit. Aligns the enforcement with the n3o PR convention and the docs (n3oltd/work#2563).

## Test plan
- [x] `grep no-work-issue` in `.github/` → only the corrected `OPT_OUT` body check + its comment.
- [ ] A PR with a `no-work-issue` line in its body skips the guard-linked check; one without (and no `re`) still fails. (verify on a test PR after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)