### PR TITLE
feat: product-gate ship-on-merge release via --internal-only

### DIFF
--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -90,10 +90,10 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # ship-on-merge: merging to the default branch IS the prod release for
-          # these repos. Move each n3oltd/work issue referenced by this merged PR
-          # straight to Released to Prod, parsing the same PR title/body that
-          # pr-dispatch used to reach Merged. mark-released is idempotent.
+          # Merging IS the prod release for ship-on-merge repos. Advance each
+          # n3oltd/work issue referenced by this merged PR to Released to Prod;
+          # --internal-only gates on the issue's Product so only internal products
+          # are released, others left for their deploy. mark-released is idempotent.
           issues=$(printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" \
             | grep -oiE 'n3oltd/work#[0-9]+' \
             | grep -oE '[0-9]+' \
@@ -105,8 +105,8 @@ jobs:
           fi
 
           for n in $issues; do
-            echo "ship-on-merge: releasing n3oltd/work#$n to prod"
-            n3o work mark-released --issue "$n" --env prod
+            echo "ship-on-merge: releasing n3oltd/work#$n to prod (if its Product is internal)"
+            n3o work mark-released --issue "$n" --env prod --internal-only
           done
 
   guard-linked:
@@ -226,6 +226,6 @@ jobs:
           fi
 
           for n in $issues; do
-            echo "ship-on-merge: releasing n3oltd/work#$n to prod"
-            n3o work mark-released --issue "$n" --env prod
+            echo "ship-on-merge: releasing n3oltd/work#$n to prod (if its Product is internal)"
+            n3o work mark-released --issue "$n" --env prod --internal-only
           done


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2557

## Summary

The two ship-on-merge release steps in the reusable `n3o-work-dispatch.yml` (PR-merge job + default-branch push job) now pass `--internal-only` to `n3o work mark-released`. The CLI then releases a referenced `n3oltd/work#NNN` issue only when its `Product.Internal` is true, leaving deploy-gated issues for their Workload's deploy.

Closes the footgun where a ship-on-merge repo released *any* referenced issue to prod regardless of product. Keys on the `Product.Internal` flag, not a hardcoded `{cli,tooling}` list.

**Depends on n3oltd/cli#166** (adds the `--internal-only` flag) — merge that first so the installed `n3o` CLI understands the flag. Mirrored in actions-babar.

This is the gating step only. The broader move (release on every merge in every repo + removing the per-caller `ship-on-merge: true` boolean) is the separate, still-paused work-dispatch caller sweep.

## Test plan

- [ ] cli#166 merged first
- [ ] ship-on-merge merge releases an internal (cli/tooling) issue
- [ ] ship-on-merge merge referencing a non-internal issue no-ops