### PR TITLE
chore: run dispatch release on every merge, product-gated

### DIFF
--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -1,6 +1,6 @@
 # Reusable workflow that syncs PR and push activity to issues in the n3oltd/work repo.
-# Dispatches PR/commit references to the n3o CLI, tracks rollouts, and (for ship-on-merge
-# repos) releases referenced work issues to prod on merge or default-branch push.
+# Dispatches PR/commit references to the n3o CLI, tracks rollouts, and on merge releases
+# each referenced work issue whose Product is internal (ship-on-merge products) to prod.
 # Call it from a repo's PR/push workflow to keep work-tracking in sync with code changes.
 name: 'n3o-work-dispatch'
 
@@ -9,10 +9,8 @@ on:
     inputs:
       ship-on-merge:
         description: >-
-          For `internal` ship-on-merge repos (no `n3o deploy` step — the n3o CLI,
-          shared actions, devops). When true, merging to the default branch
-          releases the referenced n3oltd/work issues straight to Released to Prod.
-          Leave false (default) for customer-facing repos that release via n3o deploy.
+          Deprecated and ignored — release is product-gated (issues whose Product
+          is internal) and runs on every merge. Pending removal.
         type: boolean
         required: false
         default: false
@@ -80,8 +78,8 @@ jobs:
             '{event_type: "rollout-track", client_payload: {pr_repo: $repo, pr_number: $num}}' \
             | gh api repos/n3oltd/work/dispatches -X POST --input -
 
-      - name: release referenced issues (ship-on-merge)
-        if: inputs.ship-on-merge && github.event.pull_request.merged == true
+      - name: release referenced internal issues
+        if: github.event.pull_request.merged == true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
@@ -201,8 +199,7 @@ jobs:
             --default-branch "${{ github.event.repository.default_branch }}" \
             --messages "$messages"
 
-      - name: release referenced issues (ship-on-merge)
-        if: inputs.ship-on-merge
+      - name: release referenced internal issues
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}

--- a/.github/workflows/work-dispatch.yml
+++ b/.github/workflows/work-dispatch.yml
@@ -1,16 +1,15 @@
-# Triggered workflow that runs on PR events and pushes in this repo, calling the
-# reusable n3o-work-dispatch workflow with ship-on-merge enabled to keep n3oltd/work
-# issues in sync and release them to prod on merge.
+# Triggered workflow that runs on PR events and main pushes in this repo, calling
+# the reusable n3o-work-dispatch workflow to keep n3oltd/work issues in sync.
 name: Dispatch PR status to n3oltd/work
 
 on:
   pull_request:
-    types: [opened, closed, reopened, ready_for_review, converted_to_draft]
+    types: [opened, edited, synchronize, closed, reopened, ready_for_review, converted_to_draft]
   push:
+    branches:
+      - main
 
 jobs:
   dispatch:
     uses: ./.github/workflows/n3o-work-dispatch.yml
-    with:
-      ship-on-merge: true
     secrets: inherit


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2557

## Summary

Removes the `inputs.ship-on-merge` gate from both release steps in the reusable `n3o-work-dispatch.yml`. The release is already product-gated (`--internal-only`, from #110), so dropping the boolean means a referenced `n3oltd/work#NNN` issue is released on **any** merge in **any** repo exactly when its `Product.Internal` is true — matching the merged architecture docs.

The `ship-on-merge` input is now **ignored** (description updated). It stays declared so the ~237 callers still passing `ship-on-merge: true` don't break; it'll be removed once the caller sweep drops it everywhere.

Also normalises this repo's own caller (`work-dispatch.yml`): drops `ship-on-merge`, restricts `push` to `main`, and aligns the PR `types`.

Behaviour is preserved for the repos that already ship-on-merge (still product-gated); customer repos now also release internal-product references on merge (previously they didn't pass the boolean, but a customer merge referencing a cli/tooling issue should release it — the documented design).

## Test plan

- [ ] A merge referencing an internal (cli/tooling) issue releases it to prod
- [ ] A merge referencing a non-internal issue no-ops (CLI gate)
- [ ] Callers still passing `ship-on-merge: true` don't error (input still declared)