### PR TITLE
Add hosted-runner fallover (mode input) to container build

### DIFF
--- a/.github/actions/n3o-trigger-build-service-container/action.yml
+++ b/.github/actions/n3o-trigger-build-service-container/action.yml
@@ -15,6 +15,11 @@ inputs:
     required: false
     default: '0'
 
+  mode:
+    description: "runner selection mode passed to the build: wait (self-hosted only) or fast (fall back to hosted when the fleet is saturated)."
+    required: false
+    default: wait
+
 runs:
   using: "composite"
   steps:
@@ -36,4 +41,4 @@ runs:
           echo "${REPO}: last commit ${AGE_HOURS}h ago — building"
         fi
 
-        gh workflow run build-container.yml --repo "$REPO"
+        gh workflow run build-container.yml --repo "$REPO" -f mode="${{ inputs.mode }}"

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -52,17 +52,32 @@ on:
         required: false
         default: false
 
+      mode:
+        description: "runner selection mode: wait (self-hosted only, queue) or fast (prefer self-hosted, fall back to hosted after a short wait)"
+        type: string
+        required: false
+        default: wait
+
 env:
   GH_PAT: ${{ secrets.GH_PAT }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    with:
+      mode: ${{ inputs.mode }}
+    secrets: inherit
+
   job1:
     name: build-push
+    needs: pick
 
-    # Self-hosted only (no hosted fallback) so these builds don't consume paid GitHub
-    # minutes; queueing when the fleet is busy is acceptable.
-    runs-on: n3o-github-runner
+    # Default mode (wait) keeps these builds self-hosted only so they don't consume paid GitHub
+    # minutes; queueing when the fleet is busy is acceptable. Callers that need an urgent build
+    # (e.g. a manual QA release) pass mode=fast to fall back to a hosted runner when the fleet is
+    # saturated. The pick job resolves the actual runner.
+    runs-on: ${{ needs.pick.outputs.runs-on }}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Gives the container-image build the same self-hosted→hosted fallover that main CI already uses, gated by a new `mode` input.

## Changes
- **`n3o-docker-build-push.yml`**: new `mode` input (default `wait`). Adds a `pick` job (`n3o-pick-runner.yml`) and switches the build job to `runs-on: ${{ needs.pick.outputs.runs-on }}`.
  - `mode: wait` (default) → self-hosted only, queue when busy — unchanged behaviour, no paid minutes.
  - `mode: fast` → prefer the fleet, fall back to `ubuntu-latest` after ~30s when saturated.
- **`n3o-trigger-build-service-container`**: new `mode` input, forwarded as `gh workflow run build-container.yml -f mode=...`.

Mirrors the pattern in `n3o-dotnet-build-pack-push.yml` (`mode: pull_request && 'wait' || 'fast'`).

**Why:** the EU1 nightlies refactor needs urgent, UI-triggered QA releases to fall back to hosted runners instead of queueing behind the 8-runner fleet for hours, while the scheduled nightly stays self-hosted.

Backward-compatible: `mode` defaults to `wait`, so existing callers are unaffected. The ~60 service `build-container.yml` files will be updated to accept and forward `mode` once this merges.