### PR TITLE
Default runner picking to self-hosted (wait); make fast mean hosted

### DIFF
--- a/.github/actions/n3o-trigger-build-service-container/action.yml
+++ b/.github/actions/n3o-trigger-build-service-container/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: '0'
 
   mode:
-    description: "runner selection mode passed to the build: wait (self-hosted only) or fast (fall back to hosted when the fleet is saturated)."
+    description: "runner mode: wait (self-hosted, free, queue) or fast (GitHub-hosted, immediate, billable). A [ci fast] commit marker forces fast."
     required: false
     default: wait
 

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -53,7 +53,7 @@ on:
         default: false
 
       mode:
-        description: "runner selection mode: wait (self-hosted only, queue) or fast (prefer self-hosted, fall back to hosted after a short wait)"
+        description: "runner mode: wait (self-hosted, free, queue) or fast (GitHub-hosted, immediate, billable). A [ci fast] commit marker forces fast."
         type: string
         required: false
         default: wait
@@ -66,7 +66,8 @@ jobs:
   pick:
     uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
     with:
-      mode: ${{ inputs.mode }}
+      # Default wait (self-hosted, free); a [ci fast] commit marker opts a single build into hosted.
+      mode: ${{ contains(github.event.head_commit.message, '[ci fast]') && 'fast' || inputs.mode }}
     secrets: inherit
 
   job1:

--- a/.github/workflows/n3o-dotnet-build-pack-push.yml
+++ b/.github/workflows/n3o-dotnet-build-pack-push.yml
@@ -35,7 +35,12 @@ on:
         description: directory (relative to the repo root) to run the build/commands in
         type: string
         default: src
-        
+
+      mode:
+        description: "runner mode: wait (self-hosted, free, queue) or fast (GitHub-hosted, immediate, billable). A [ci fast] commit marker forces fast."
+        type: string
+        default: wait
+
 env:
   GH_PAT: ${{ secrets.GH_PAT }}
   AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}
@@ -46,7 +51,8 @@ jobs:
   pick:
     uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
     with:
-      mode: ${{ github.event_name == 'pull_request' && 'wait' || 'fast' }}
+      # Default wait (self-hosted, free); a [ci fast] commit marker opts a single build into hosted.
+      mode: ${{ contains(github.event.head_commit.message, '[ci fast]') && 'fast' || inputs.mode }}
     secrets: inherit
 
   build:

--- a/.github/workflows/n3o-dotnet-build.yml
+++ b/.github/workflows/n3o-dotnet-build.yml
@@ -15,6 +15,11 @@ on:
         type: string
         default: src
 
+      mode:
+        description: "runner mode: wait (self-hosted, free, queue) or fast (GitHub-hosted, immediate, billable). A [ci fast] commit marker forces fast."
+        type: string
+        default: wait
+
 env:
   GH_PAT: ${{ secrets.GH_PAT }}
 
@@ -22,7 +27,8 @@ jobs:
   pick:
     uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
     with:
-      mode: ${{ github.event_name == 'pull_request' && 'wait' || 'fast' }}
+      # Default wait (self-hosted, free); a [ci fast] commit marker opts a single build into hosted.
+      mode: ${{ contains(github.event.head_commit.message, '[ci fast]') && 'fast' || inputs.mode }}
     secrets: inherit
 
   build:

--- a/.github/workflows/n3o-pick-runner.yml
+++ b/.github/workflows/n3o-pick-runner.yml
@@ -1,40 +1,41 @@
 # Picks a job's runner. A caller runs this as a `pick` job and feeds its `runs-on` output to
 # the real job's `runs-on`. Two modes:
-#   fast (default) — prefer the self-hosted fleet; if none is free, wait up to `wait-seconds`
-#                    for one, then fall back to a GitHub-hosted runner. For urgent jobs that
-#                    must not queue (e.g. main CI).
-#   wait           — self-hosted only; the job queues until a runner frees up, never falling
-#                    back to a (paid) hosted runner. For jobs where delay is fine.
-# Public repos always get the hosted fallback in both modes (the runner group is
-# private-repo only).
+#   wait (default) — self-hosted only. The job queues on the fleet until a runner frees up.
+#                    Free (no billable minutes) and never gets stuck — GitHub assigns it the
+#                    next idle runner. The right default for routine CI: PR-merge builds and
+#                    the automated NuGet-bump sweep both run here for free.
+#   fast           — GitHub-hosted. Bypasses the fleet entirely for an immediate start with no
+#                    queue. Billable, so it's an explicit opt-in for when a developer is blocked
+#                    and needs a build now (e.g. while the fleet is mid-burst).
+# Public repos always get the hosted runner (the self-hosted runner group is private-repo only).
+#
+# There is deliberately no "prefer self-hosted, fall back to hosted" middle ground. That relied
+# on a point-in-time count of idle runners, which is a race: a job could commit to the fleet on
+# a stale/transient idle reading and then starve, since GitHub can't reroute a queued job. wait
+# (honest queue) and fast (honest hosted) have no such race.
 name: n3o pick runner
 
 on:
   workflow_call:
     inputs:
       self-hosted-label:
-        description: The self-hosted runner label to prefer.
+        description: The self-hosted runner label used in wait mode.
         type: string
         required: false
         default: n3o-github-runner
       fallback:
-        description: The GitHub-hosted runner to fall back to when the fleet is saturated.
+        description: The GitHub-hosted runner used in fast mode (and for public repos).
         type: string
         required: false
         default: ubuntu-latest
-      wait-seconds:
-        description: (fast mode) How long to wait for a free self-hosted runner before falling back.
-        type: number
-        required: false
-        default: 30
       mode:
-        description: "fast (prefer self-hosted, fall back to hosted) or wait (self-hosted only, queue)."
+        description: "wait (self-hosted, free, queues until a runner frees) or fast (GitHub-hosted, immediate, billable)."
         type: string
         required: false
-        default: fast
+        default: wait
     outputs:
       runs-on:
-        description: The chosen runs-on value (the self-hosted label or the fallback).
+        description: The chosen runs-on value (the self-hosted label or the hosted fallback).
         value: ${{ jobs.pick.outputs.runs-on }}
 
 jobs:
@@ -43,59 +44,28 @@ jobs:
     outputs:
       runs-on: ${{ steps.pick.outputs.runs-on }}
     steps:
-      # Listing org runners needs an App token (the default GITHUB_TOKEN can't). Only
-      # private repos query the fleet — public repos always fall back to hosted — so only
-      # they mint a token, which keeps the App secret scoped to private repos.
-      - id: identity
-        if: ${{ github.event.repository.private }}
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.N3O_GITHUB_RUNNERS_APP_ID }}
-          private-key: ${{ secrets.N3O_GITHUB_RUNNERS_APP_PRIVATE_KEY }}
-          owner: n3oltd
-
       - id: pick
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.identity.outputs.token }}
           SELF_HOSTED: ${{ inputs.self-hosted-label }}
           FALLBACK: ${{ inputs.fallback }}
-          WAIT_SECONDS: ${{ inputs.wait-seconds }}
           MODE: ${{ inputs.mode }}
           IS_PRIVATE: ${{ github.event.repository.private }}
         run: |
           choose() { echo "runs-on=$1" >> "$GITHUB_OUTPUT"; echo "picked runner: $1"; }
 
-          # The self-hosted runner group is private-repo only, so public repos can't use it.
+          # The self-hosted runner group is private-repo only, so public repos always go hosted.
           if [ "$IS_PRIVATE" != "true" ]; then
-            echo "public repo -> hosted fallback"
+            echo "public repo -> hosted"
             choose "$FALLBACK"; exit 0
           fi
 
-          # wait mode: self-hosted only — let GitHub queue the job until a runner frees up.
-          if [ "$MODE" = wait ]; then
-            echo "wait mode (private repo) -> self-hosted, queue if busy"
-            choose "$SELF_HOSTED"; exit 0
+          # fast: skip the fleet for an immediate, never-queued start (billable).
+          if [ "$MODE" = fast ]; then
+            echo "fast mode -> hosted (immediate, never queues)"
+            choose "$FALLBACK"; exit 0
           fi
 
-          # Number of online + idle runners carrying the self-hosted label. On any API
-          # hiccup, treat as 0 so we lean towards falling back rather than risk queueing.
-          idle_count() {
-            gh api "orgs/n3oltd/actions/runners" --paginate \
-              --jq "[.runners[] | select(.status==\"online\" and .busy==false)
-                     | select(any(.labels[]; .name==\"$SELF_HOSTED\"))] | length" 2>/dev/null || echo 0
-          }
-
-          # Prefer self-hosted; if none free, wait up to WAIT_SECONDS for one to free up
-          # before falling back to hosted (avoids paying for hosted on brief saturation).
-          deadline=$(( SECONDS + WAIT_SECONDS ))
-          while :; do
-            idle=$(idle_count)
-            echo "idle $SELF_HOSTED runners: ${idle:-0}"
-            if [ "${idle:-0}" -ge 1 ]; then choose "$SELF_HOSTED"; exit 0; fi
-            [ "$SECONDS" -ge "$deadline" ] && break
-            echo "no free $SELF_HOSTED runner; waiting up to ${WAIT_SECONDS}s…"
-            sleep 5
-          done
-          echo "no $SELF_HOSTED capacity after ${WAIT_SECONDS}s -> hosted fallback"
-          choose "$FALLBACK"
+          # wait (default): queue on the fleet — free, and assigned the next idle runner.
+          echo "wait mode -> self-hosted (free; queues until a runner frees)"
+          choose "$SELF_HOSTED"

--- a/.github/workflows/n3o-pick-runner.yml
+++ b/.github/workflows/n3o-pick-runner.yml
@@ -8,11 +8,6 @@
 #                    queue. Billable, so it's an explicit opt-in for when a developer is blocked
 #                    and needs a build now (e.g. while the fleet is mid-burst).
 # Public repos always get the hosted runner (the self-hosted runner group is private-repo only).
-#
-# There is deliberately no "prefer self-hosted, fall back to hosted" middle ground. That relied
-# on a point-in-time count of idle runners, which is a race: a job could commit to the fleet on
-# a stale/transient idle reading and then starve, since GitHub can't reroute a queued job. wait
-# (honest queue) and fast (honest hosted) have no such race.
 name: n3o pick runner
 
 on:

--- a/.github/workflows/n3o-pick-runner.yml
+++ b/.github/workflows/n3o-pick-runner.yml
@@ -29,7 +29,7 @@ on:
         required: false
         default: ubuntu-latest
       mode:
-        description: "wait (self-hosted, free, queues until a runner frees) or fast (GitHub-hosted, immediate, billable)."
+        description: "runner mode: wait (self-hosted, free, queue) or fast (GitHub-hosted, immediate, billable). A [ci fast] commit marker forces fast."
         type: string
         required: false
         default: wait


### PR DESCRIPTION
## Problem

Main CI (`n3o-dotnet-build-pack-push`) serves two traffic sources through the **same** workflow:

1. **All-day PR merges** — should run free on the self-hosted fleet.
2. **The twice-daily org-wide NuGet bump** — up to **~200 builds in a ~2-minute window**.

Both ran in **`fast`** mode, which counted idle org runners and committed the job to the self-hosted fleet if any were free. That count is a **TOCTOU race** against a shared, fixed **8-runner ephemeral pool** (`devops/apps/n3o-github-runner`): the idle runner gets claimed by a competing job — or is an ephemeral-teardown phantom — before the job dispatches, and **GitHub can't reroute a queued job**, so it starves. Observed live: a `lib-be-work` build sat `queued` ~14 min (8 runners busy, 0 idle) while other repos' CI cycled through, until it was cancelled.

No per-job idle heuristic can fix this: a fixed pool of 8 can't absorb a 200-build burst (~2–3h of serial work), and the race is inherent to a check-then-commit against shared capacity.

## Fix

Replace the racy "prefer self-hosted, fall back to hosted" middle ground with **two honest modes**:

- **`wait` (now the default)** → self-hosted, **free**, queues for the next idle runner. No idle-count guess, so it **can't get stuck**. PR merges and the bump sweep both run here for free (the sweep drains in the background; nobody's blocked on it).
- **`fast`** → GitHub-hosted, immediate, **billable** — an explicit opt-in for when a developer is blocked and needs a build now.

Opt into `fast` per-build via a **`[ci fast]` commit marker** or the `mode` input.

### Changes
- `n3o-pick-runner.yml` — two modes (`wait` default / `fast`); removed the idle-count loop, the 30s wait + `wait-seconds` input, and the runner-listing App-token step (also clears the `create-github-app-token` Node 20 deprecation annotation).
- `n3o-dotnet-build-pack-push.yml` — added `mode` input (default `wait`); effective mode = `[ci fast]` marker → `fast`, else input.
- `n3o-dotnet-build.yml` — same treatment for PR validation builds.

EU1 nightlies and the container build path already thread `mode`, so they're unaffected; their manual-dispatch `fast` now simply means hosted (matching their comments).

## Net behaviour
- PR merges → self-hosted, free, never stuck.
- Bot NuGet-bump burst → self-hosted, free, queues and drains in the background, no race.
- `[ci fast]` → hosted, immediate, for anyone blocked.
- Hosted minutes accrue only for explicit `fast` builds, not routine all-day traffic.

## Follow-ups (not in this PR)
- `n3o nuget upgrade --fast` flag to stamp `[ci fast]` for a dev-urgent single-repo bump (CLI change).
- Burst-shrinking: coalesce the bump cascade (`concurrency: cancel-in-progress`), tier by dependency, warm NuGet caches.

no-work-issue