### PR TITLE
Avoid Docker Hub rate limit on fleet builds

### DIFF
--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -85,12 +85,7 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
-      # Authenticate Docker Hub so fleet builds (shared egress IP) don't hit the anonymous pull
-      # rate limit when buildx pulls its builder image. Skipped when no credentials are configured.
       - name: docker hub login
-        if: env.DOCKERHUB_USERNAME != ''
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -119,8 +114,6 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Plain curl rather than a Docker-container action so this needs no docker.io base-image pull
-      # (the wei/wget action was FROM alpine and tripped Docker Hub's rate limit on the fleet).
       - name: fetch dockerfile
         if: steps.check-existing.outputs.exists != 'true'
         shell: bash

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -85,6 +85,17 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
+      # Authenticate Docker Hub so fleet builds (shared egress IP) don't hit the anonymous pull
+      # rate limit when buildx pulls its builder image. Skipped when no credentials are configured.
+      - name: docker hub login
+        if: env.DOCKERHUB_USERNAME != ''
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Bootstraps the buildx builder against the DinD daemon; not a redundant install.
       - id: buildx
         uses: docker/setup-buildx-action@v4
@@ -108,11 +119,14 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Plain curl rather than a Docker-container action so this needs no docker.io base-image pull
+      # (the wei/wget action was FROM alpine and tripped Docker Hub's rate limit on the fleet).
       - name: fetch dockerfile
         if: steps.check-existing.outputs.exists != 'true'
-        uses: wei/wget@v1
-        with:
-          args: -O ${{ inputs.dockerfile }} https://raw.githubusercontent.com/n3oltd/actions/main/docker/${{ inputs.dockerfile }}
+        shell: bash
+        run: |
+          curl -fsSL -o "${{ inputs.dockerfile }}" \
+            "https://raw.githubusercontent.com/n3oltd/actions/main/docker/${{ inputs.dockerfile }}"
 
       - id: metadata
         name: metadata


### PR DESCRIPTION
Self-hosted fleet builds share one egress IP and hit Docker Hub's **anonymous pull rate limit (HTTP 429)**. A wait-mode nightly smoke run failed because `svc-be-accounting`'s build couldn't pull `alpine`:

```
#2 [internal] load metadata for docker.io/library/alpine:latest
ERROR: 429 Too Many Requests — You have reached your unauthenticated pull rate limit
  Dockerfile:1  >>> FROM alpine     # the wei/wget@v1 action's own image
```

(Fast-mode runs dodged this because their builds fell back to hosted runners.)

## Changes
1. **Drop `wei/wget@v1`; fetch the Dockerfile with `curl`.** `wei/wget` is a Docker-container action (`FROM alpine`) whose image must be pulled from docker.io every run — for a step that just downloads a file. `curl` needs no container and no Docker Hub pull, and is faster.
2. **Authenticate Docker Hub before buildx setup.** A guarded `docker/login-action` (docker.io) so the buildx builder-image pull (`moby/buildkit`) — the other latent docker.io dependency — uses an authenticated, per-account limit instead of the anonymous per-IP one.

The service image itself is unaffected (`n3o-dotnet` is `FROM mcr.microsoft.com/dotnet/*` — Microsoft Container Registry, no Docker Hub limit).

**Requires** org secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. The login step is guarded (`if: env.DOCKERHUB_USERNAME != ''`) so builds don't break before the secrets are added — but the buildkit pull stays anonymous until they are. The `curl` change helps regardless.