### PR TITLE
Coalesce main-CI build-pack-push runs per repo+ref

### DIFF
--- a/.github/workflows/n3o-dotnet-build-pack-push.yml
+++ b/.github/workflows/n3o-dotnet-build-pack-push.yml
@@ -41,6 +41,13 @@ on:
         type: string
         default: wait
 
+# Coalesce a repo's in-flight runs on the same ref so the NuGet-bump cascade (which can re-commit
+# the same repo several times in minutes) only builds the latest. Continuously-bumped feeds always
+# consume the newest version, so skipping superseded intermediates is safe.
+concurrency:
+  group: dotnet-build-pack-push-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GH_PAT: ${{ secrets.GH_PAT }}
   AZURE_TENANT_ID: ${{ secrets.N3O_CLI_AZURE_TENANT_ID }}

--- a/.github/workflows/n3o-dotnet-build-pack-push.yml
+++ b/.github/workflows/n3o-dotnet-build-pack-push.yml
@@ -41,9 +41,7 @@ on:
         type: string
         default: wait
 
-# Coalesce a repo's in-flight runs on the same ref so the NuGet-bump cascade (which can re-commit
-# the same repo several times in minutes) only builds the latest. Continuously-bumped feeds always
-# consume the newest version, so skipping superseded intermediates is safe.
+# Build only the latest commit per repo+ref; cancel superseded bump-cascade runs.
 concurrency:
   group: dotnet-build-pack-push-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Follow-up to #114 (burst-shrinking). The org-wide NuGet-bump sweep can re-commit the same repo several times within minutes (e.g. `lib-be-sql` got 4 "Upgraded N3O packages" commits in ~2.5h when a foundational package republished). Each commit currently spawns its own `main-ci` build.

Adds a top-level `concurrency` group (`per repo + ref`) with `cancel-in-progress: true` to `n3o-dotnet-build-pack-push`, so only the latest build for a repo runs and superseded ones are cancelled. This lives in the reusable workflow, so **no per-repo changes** are needed — all consumers inherit it via `@main`.

Safe for this pipeline: the feed is continuously bumped and downstream always consumes the newest version, so skipping a superseded intermediate (or an orphaned partial publish) is harmless — the next build publishes the current set.

no-work-issue