### PR TITLE
dotnet-build-pack-push: optional Node setup + npm/turbo cache

### DIFF
--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -15,6 +15,14 @@ on:
         type: string
         default: 10.x
 
+      setup-node:
+        description: >-
+          whether to set up Node.js (and cache ~/.npm + .turbo) before the build.
+          Enable for repos whose MSBuild build runs npm/Turbo (e.g. backoffice
+          frontend plugins). The version is read from a .nvmrc at the repo root.
+        type: boolean
+        default: false
+
       working-directory:
         description: directory (relative to the repo root) to run the build/commands in
         type: string
@@ -89,6 +97,25 @@ jobs:
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
+
+      # Frontend plugins run npm ci + Turbo from MSBuild, so Node must be present
+      # before the build. setup-node's built-in cache handles ~/.npm (keyed on the
+      # lockfile); the version comes from the repo-root .nvmrc.
+      - uses: actions/setup-node@v4
+        if: ${{ inputs.setup-node }}
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+
+      - name: cache turbo
+        if: ${{ inputs.setup-node && runner.environment == 'github-hosted' }}
+        uses: actions/cache@v4
+        with:
+          path: ${{ inputs.working-directory }}/.turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
 
       - id: prepare
         name: Set version

--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -98,9 +98,6 @@ jobs:
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
-      # Frontend plugins run npm ci + Turbo from MSBuild, so Node must be present
-      # before the build. setup-node's built-in cache handles ~/.npm (keyed on the
-      # lockfile); the version comes from the repo-root .nvmrc.
       - uses: actions/setup-node@v4
         if: ${{ inputs.setup-node }}
         with:


### PR DESCRIPTION
## What

Adds an opt-in `setup-node` input to the reusable `dotnet-build-pack-push.yml`. When `true`, before the .NET build it:
- sets up Node.js (version read from the consumer repo's root `.nvmrc`) with setup-node's built-in `~/.npm` cache (keyed on `<working-directory>/package-lock.json`), and
- restores/saves a `<working-directory>/.turbo` cache (GitHub-hosted runners only).

## Why

The Umbraco backoffice **React Client Infrastructure** (n3oltd/umbraco-extensions PR #863) makes MSBuild run `npm ci` + Turbo to build the backoffice frontend bundles during `dotnet build`/`pack`. CI runners therefore need Node available before the build, plus caching so it isn't reinstalled/rebuilt every run.

## Safety

- Defaults to `false` — every existing consumer is unaffected (no Node step runs).
- Only consumers that set `setup-node: true` (and ship a root `.nvmrc`) get the new behaviour.

## Consumer change (follow-up)

`n3oltd/umbraco-extensions` will set `setup-node: true` on its `dotnet-build-pack-push.yml` callers (`v17-ci.yml`, `main-ci.yml`, `tag-ci.yml`) once this merges.

re n3oltd/work#729

🤖 Generated with [Claude Code](https://claude.com/claude-code)