### PR TITLE
Add fast input to n3o-dotnet-update-nuget

### DIFF
--- a/.github/workflows/n3o-dotnet-update-nuget.yml
+++ b/.github/workflows/n3o-dotnet-update-nuget.yml
@@ -10,6 +10,11 @@ on:
         description: Optional single repo name. If omitted, the whole org is processed.
         required: false
         type: string
+      fast:
+        description: Mark the upgrade commits [ci fast] so downstream builds run on hosted runners instead of queueing on the self-hosted fleet.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   upgrade:
@@ -35,8 +40,10 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
         run: |
+          FAST=""
+          if [ "${{ inputs.fast }}" = "true" ]; then FAST="--fast"; fi
           if [ -n "${{ inputs.repo }}" ]; then
-            n3o nuget upgrade --our-packages --target=remote --repo="${{ inputs.repo }}" --no-input
+            n3o nuget upgrade --our-packages --target=remote --repo="${{ inputs.repo }}" --no-input $FAST
           else
-            n3o nuget upgrade --our-packages --target=remote --no-input
+            n3o nuget upgrade --our-packages --target=remote --no-input $FAST
           fi


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Adds a `fast` boolean `workflow_call` input to `n3o-dotnet-update-nuget.yml`. When true, the upgrade step passes `--fast` to `n3o nuget upgrade`, marking the commits `[ci fast]` so downstream builds run on hosted runners. Defaults to `false` (self-hosted fleet, queued).

Depends on n3oltd/cli (relaxed `--fast` validation) being merged and published first — org-wide `--fast` fails validation on older CLI builds.

## Test plan

- [ ] Dispatch a caller with `fast: true` and confirm the upgrade commits carry `[ci fast]` and downstream builds pick the hosted runner
- [ ] Confirm `fast: false` (default) still queues on the self-hosted fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
