### PR TITLE
ci: replace wei/wget Docker action with curl in build workflows

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -68,9 +68,10 @@ jobs:
           password: ${{ secrets.acr-password }}
 
       - name: Fetch Dockerfile
-        uses: wei/wget@v1
-        with:
-          args: -O ${{ inputs.dockerfile }} https://raw.githubusercontent.com/n3oltd/actions/main/docker/${{ inputs.dockerfile }}
+        shell: bash
+        run: |
+          curl -fsSL -o "${{ inputs.dockerfile }}" \
+            "https://raw.githubusercontent.com/n3oltd/actions/main/docker/${{ inputs.dockerfile }}"
 
       - id: meta
         name: Set tags

--- a/.github/workflows/n3o-docker-build-push-pgbouncer.yml
+++ b/.github/workflows/n3o-docker-build-push-pgbouncer.yml
@@ -25,9 +25,10 @@ jobs:
           password: ${{ secrets.ACR_PASSWORD }}
 
       - name: fetch dockerfile
-        uses: wei/wget@v1
-        with:
-          args: -O pgbouncer https://raw.githubusercontent.com/n3oltd/actions/main/docker/pgbouncer
+        shell: bash
+        run: |
+          curl -fsSL -o pgbouncer \
+            https://raw.githubusercontent.com/n3oltd/actions/main/docker/pgbouncer
 
       - id: meta-pgbouncer
         name: prepare pgbouncer

--- a/.github/workflows/n3o-docker-build-push-postgres.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres.yml
@@ -25,9 +25,10 @@ jobs:
           password: ${{ secrets.ACR_PASSWORD }}
 
       - name: fetch dockerfile
-        uses: wei/wget@v1
-        with:
-          args: -O postgres https://raw.githubusercontent.com/n3oltd/actions/main/docker/postgres
+        shell: bash
+        run: |
+          curl -fsSL -o postgres \
+            https://raw.githubusercontent.com/n3oltd/actions/main/docker/postgres
 
       - id: meta-postgres
         name: prepare postgres


### PR DESCRIPTION
re n3oltd/work#2641

## Summary

While investigating intermittent eu1-nightlies failures (in n3oltd/deployments), the deeper cause turned out to be transient failures in the per-service container builds, not the nightlies workflow itself. The nightlies job watches every dispatched build-container.yml with `gh run watch --exit-status`, so any failed service build fails the whole nightly and the QA deploy never runs.

`wei/wget@v1` is a Docker-container action. GitHub builds its image (`FROM alpine`) at job-init via an unauthenticated Docker Hub pull, before the docker/login-action step. Under the nightly fan-out (~55 concurrent builds sharing the runner egress IPs) this intermittently trips the Docker Hub anonymous pull-rate limit (HTTP 429) and fails the build.

This PR replaces the three remaining `wei/wget@v1` usages with a plain `curl -fsSL` run step, the exact pattern already used in n3o-docker-build-push.yml:

- docker-build-push.yml (legacy)
- n3o-docker-build-push-postgres.yml
- n3o-docker-build-push-pgbouncer.yml

Fetching the Dockerfile no longer depends on building or pulling a Docker-container action image, removing this 429 path entirely.

Note: the primary current nightly failures (svc-be-counters, svc-be-esignatures on 2026-06-23) are a separate transient infra issue, tracked in n3oltd/work#2641: the self-hosted runner DinD daemon (tcp://localhost:2375) is occasionally not ready when GitHub prepares the getsentry/action-release@v3 Docker-container action image at job-init. That needs a runner-infra fix and is not addressed here.

## Test plan

- [ ] Trigger build-container.yml on a postgres-backed service; confirm the Fetch Dockerfile step uses curl and succeeds
- [ ] Confirm n3o-postgres and n3o-pgbouncer image builds still fetch their Dockerfiles and push to ACR
- [ ] Run eu1-nightlies (workflow_dispatch) and confirm no service build fails on the alpine 429 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)