### PR TITLE
Seed read-only/read-write agent roles on Postgres startup

### DIFF
--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -91,5 +91,18 @@ until pg_isready -U "${POSTGRES_USER}" -d :"${POSTGRES_USER}"; do
   sleep 2
 done
 
+# Seed the read-only / read-write agent roles (idempotent; md5 so pgbouncer can proxy them)
+if [ -n "${AGENT_RO_PASSWORD}" ] && [ -n "${AGENT_RW_PASSWORD}" ]; then
+  psql -U "${POSTGRES_USER}" -d postgres -v ro_pw="${AGENT_RO_PASSWORD}" -v rw_pw="${AGENT_RW_PASSWORD}" <<'EOSQL'
+SET password_encryption = 'md5';
+DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'n3o_agent_ro') THEN CREATE ROLE n3o_agent_ro LOGIN; END IF; END $$;
+DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'n3o_agent_rw') THEN CREATE ROLE n3o_agent_rw LOGIN; END IF; END $$;
+ALTER ROLE n3o_agent_ro PASSWORD :'ro_pw';
+ALTER ROLE n3o_agent_rw PASSWORD :'rw_pw';
+GRANT pg_read_all_data TO n3o_agent_ro;
+GRANT pg_read_all_data, pg_write_all_data TO n3o_agent_rw;
+EOSQL
+fi
+
 pg_pid=$!
 wait "$pg_pid"


### PR DESCRIPTION
## Summary

The postgres image entrypoint now creates `n3o_agent_ro` (`pg_read_all_data`) and `n3o_agent_rw` (`pg_read_all_data` + `pg_write_all_data`) on every start, idempotently, with **md5** passwords (so pgbouncer can proxy them — PG17 defaults to scram, which it cannot). Passwords come from `AGENT_RO_PASSWORD` / `AGENT_RW_PASSWORD` (the per-server secret); the block is skipped when they are unset.

These back the read-only n3o CLI MCP database tools. **Land order:** this (rebuild image) → cli deploy PR (#189, ships the passwords + redeploys) → lib-be-sql `GRANT CONNECT` PR.

re n3oltd/work#2697

## Test plan

- [ ] Rebuild the `n3o-postgres` image from this branch
- [ ] Deploy/restart a Postgres server with `AGENT_RO_PASSWORD`/`AGENT_RW_PASSWORD` set; confirm `n3o_agent_ro`/`n3o_agent_rw` exist with md5 passwords and the expected grants
- [ ] Confirm the roles log in through pgbouncer and the read-only role cannot write

🤖 Generated with [Claude Code](https://claude.com/claude-code)
