### PR TITLE
Harden /babar: survive turn/cost exhaustion and always report back

### DIFF
--- a/.github/actions/n3o-claude-run/action.yml
+++ b/.github/actions/n3o-claude-run/action.yml
@@ -51,8 +51,16 @@ inputs:
 
 outputs:
   result:
-    description: Final result text from Claude
+    description: Final result text from Claude (empty when the run ended without a result, e.g. error_max_turns)
     value: ${{ steps.run.outputs.result }}
+  last-text:
+    description: >
+      The last assistant text message of the run. Unlike `result` this is populated even when the
+      run is cut short (error_max_turns / error_max_cost), so a caller can report partial findings.
+    value: ${{ steps.run.outputs.last-text }}
+  subtype:
+    description: Result subtype reported by Claude (e.g. success, error_max_turns, error_max_cost)
+    value: ${{ steps.run.outputs.subtype }}
   is-error:
     description: Whether Claude reported an error result
     value: ${{ steps.run.outputs.is-error }}
@@ -144,15 +152,27 @@ runs:
         is_error=$(printf '%s' "$result_json" | jq -r '.is_error // false')
         num_turns=$(printf '%s' "$result_json" | jq -r '.num_turns // 0')
         cost_usd=$(printf '%s' "$result_json" | jq -r '.total_cost_usd // 0')
+        subtype=$(printf '%s' "$result_json" | jq -r '.subtype // ""')
         result_text=$(printf '%s' "$result_json" | jq -r '.result // ""')
+
+        # The final result message carries no text when the run is cut short (e.g. error_max_turns),
+        # so also surface the last assistant text — that's the agent's most recent reasoning/findings
+        # and is what a caller reports when the run never produced a clean result. Capped so a runaway
+        # message can't blow the step-output / downstream comment size limits.
+        last_text=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text' "$raw" 2>/dev/null | tail -200)
+        last_text=${last_text:0:8000}
 
         {
           echo "is-error=$is_error"
           echo "num-turns=$num_turns"
           echo "cost-usd=$cost_usd"
+          echo "subtype=$subtype"
           echo "result<<__N3O_RESULT_EOF__"
           printf '%s\n' "$result_text"
           echo "__N3O_RESULT_EOF__"
+          echo "last-text<<__N3O_LASTTEXT_EOF__"
+          printf '%s\n' "$last_text"
+          echo "__N3O_LASTTEXT_EOF__"
         } >> "$GITHUB_OUTPUT"
 
         echo "Claude run: subtype=${result_json:+$(printf '%s' "$result_json" | jq -r '.subtype // "?"')} turns=$num_turns cost=\$$cost_usd"

--- a/.github/workflows/n3o-babar.yml
+++ b/.github/workflows/n3o-babar.yml
@@ -137,13 +137,60 @@ jobs:
             exit 1
           fi
 
+      # continue-on-error keeps the job alive after a failed/cut-short run so the report-back step
+      # still fires — the thread must never go silent. WebFetch/WebSearch let the agent follow
+      # Sentry/doc links rather than stall on a rejected permission. max-turns/max-cost are runaway
+      # guards, not budgets — sized for a diagnose that clones and build-verifies.
       - name: Run Claude
+        id: claude
+        continue-on-error: true
         uses: n3oltd/actions/.github/actions/n3o-claude-run@main
         with:
           prompt-file: ${{ runner.temp }}/prompt.md
           oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed-tools: Read Grep Glob Edit Write Bash mcp__n3o__*
+          allowed-tools: Read Grep Glob Edit Write Bash WebFetch WebSearch mcp__n3o__*
           mcp-config: ${{ env.MCP_CONFIG }}
-          max-turns: '120'
-          max-cost-usd: '5'
+          max-turns: '150'
+          max-cost-usd: '6'
           github-token: ${{ secrets.GH_PAT }}
+
+      # The prompt posts its own result on success; a cut-short (error_max_turns/max_cost) or
+      # crashed run posts nothing, so report back here. Fire only when Claude errored or produced
+      # no result at all (empty subtype) — a clean run, and the post-run cost tripwire where the
+      # agent already commented, are both left alone, so we never double-post.
+      - name: Report back when the run could not finish
+        if: ${{ steps.claude.outputs.is-error == 'true' || steps.claude.outputs.subtype == '' }}
+        env:
+          COMMAND: ${{ steps.parse.outputs.command }}
+          SUBTYPE: ${{ steps.claude.outputs.subtype }}
+          NUM_TURNS: ${{ steps.claude.outputs.num-turns }}
+          COST_USD: ${{ steps.claude.outputs.cost-usd }}
+          LAST_TEXT: ${{ steps.claude.outputs.last-text }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          case "$SUBTYPE" in
+            error_max_turns) reason="ran out of its turn budget (${NUM_TURNS:-?} turns)";;
+            error_max_cost)  reason="hit its cost ceiling (\$${COST_USD:-?})";;
+            "")              reason="failed before producing a result";;
+            *)               reason="ended early ($SUBTYPE)";;
+          esac
+          {
+            echo "@$COMMENTER \`/babar $COMMAND\` couldn't complete — it $reason, so it didn't finish its reply."
+            echo
+            if [ -n "$LAST_TEXT" ]; then
+              echo "Here's how far it got before stopping:"
+              echo
+              echo "> ${LAST_TEXT//$'\n'/$'\n'> }"
+              echo
+            fi
+            echo "Re-run with a hint to narrow the task — add a focus or the likely area after the command, e.g. \`/babar $COMMAND <focus or area>\` — so it can finish within budget. [Run log]($RUN_URL)."
+          } > "$RUNNER_TEMP/babar-failure.md"
+          gh issue comment "$THREAD" --repo "$GITHUB_REPOSITORY" --body-file "$RUNNER_TEMP/babar-failure.md"
+
+      # Re-surface the failure continue-on-error masked, so `gh run list` and required checks
+      # still reflect that the run did not succeed.
+      - name: Fail the job if the run did not succeed
+        if: ${{ steps.claude.outcome == 'failure' }}
+        run: |
+          echo "::error::Claude run did not succeed (subtype=${{ steps.claude.outputs.subtype }}, is_error=${{ steps.claude.outputs.is-error }})"
+          exit 1


### PR DESCRIPTION
## Summary

`/babar diagnose` on n3oltd/work#669 hit `error_max_turns` (121/120 turns, $5.66 > $5) and ended as a **silent** `failure` — the prompt posts its own result and never got there, so the thread went quiet after the 👀 reaction. This hardens the bot so a cut-short or crashed run always reports back, and gives a real diagnose a little more room to finish.

**`n3o-babar.yml`**
- **Always report back.** `continue-on-error` on the run, then a step that posts a comment to the thread whenever the run is cut short (`error_max_turns` / `error_max_cost`) or crashes before producing a result — with the reason, turn/cost, any **partial findings**, and a run link. Guarded so it never double-posts on a clean run (or on the post-run cost tripwire, where the agent already commented). A final step re-fails the job so `gh run list` / required checks still reflect failure.
- **Stop wasting turns.** Add `WebFetch`/`WebSearch` to `allowed-tools` — the #669 run burned 4 turns on rejected `WebFetch` permission prompts.
- **A little more headroom.** `max-turns` 120→150, `max-cost-usd` $5→$6. Runaway guards, not budgets; the heaviest command (diagnose) clones repos and build-verifies a fix. `timeout-minutes` left at 45 (150 turns fits comfortably — the #669 run did 121 in ~23 min).

**`n3o-claude-run`**
- Expose `subtype` and `last-text` outputs. `result` is empty on `error_max_turns`; `last-text` (the last assistant text, capped) is populated even then, so the caller can surface partial findings.

## Test plan

- [x] `python3` `yaml.safe_load` parses both `n3o-babar.yml` and `n3o-claude-run/action.yml`.
- [x] `bash -n` on the report-back snippet, plus a render of the blockquote/partial-findings path, verified locally.
- [ ] Live `issue_comment` trigger on a private repo (self-hosted fleet): exercise `/babar` on a throwaway issue and confirm (a) a normal run still posts exactly one comment, (b) a forced cut-short run posts the fallback comment with partial findings and the run still shows as failed.

re n3oltd/work#2755
