### PR TITLE
Add canonical oauth-next-static Dockerfile (Next.js app + static behind oauth2-proxy)

### DIFF
--- a/docker/oauth-next-static
+++ b/docker/oauth-next-static
@@ -1,0 +1,92 @@
+# syntax=docker/dockerfile:1
+#
+# oauth-next-static — oauth2-proxy fronting a Next.js app AND a static site as a
+# single origin (Entra sign-in). Companion to oauth-static-site / oauth-storybook
+# for repos that need a dynamic Next.js server alongside static files behind auth.
+#
+#   ${APP_ROUTE}*  -> the Next.js server (next start)            :${APP_PORT}
+#   /*             -> the static site (npm run build -> ./out)    /var/www
+#
+# Built by n3o-docker-build-push.yml. The consuming repo provides its source as
+# the build context (context: .) and passes its specifics as build-args:
+#
+#   build-args: |
+#     APP_DIR=path/to/next-app     # context-relative dir of the Next.js app (pnpm)
+#     APP_ROUTE=/app               # the app's basePath / upstream route prefix
+#     APP_PORT=3000                # port `next start` listens on
+#
+# Conventions the consuming repo must follow:
+#   - root package.json `npm run build` emits the static site into ./out
+#   - APP_DIR is a self-contained pnpm Next.js app (pnpm install / pnpm build /
+#     next start) whose next config sets basePath to APP_ROUTE
+#
+# Auth settings (provider/client-id/secret/cookie/email-domains) are applied at
+# deploy time by oauth-static-site-deploy.yml, not baked here.
+
+ARG APP_DIR=app
+ARG APP_ROUTE=/app
+ARG APP_PORT=3000
+
+########################
+### oauth2-proxy binary (pinned; bump deliberately)
+########################
+FROM quay.io/oauth2-proxy/oauth2-proxy:v7.8.1 AS oauth2proxy
+
+########################
+### build the Next.js app
+########################
+FROM node:22-slim AS app
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable
+WORKDIR /app
+ARG APP_DIR
+COPY ${APP_DIR}/ ./
+RUN pnpm install --frozen-lockfile
+RUN pnpm build
+
+########################
+### build the static site (-> ./out, served at /var/www)
+########################
+FROM node:22-slim AS static
+WORKDIR /site
+COPY . .
+RUN npm ci --omit=dev
+RUN npm run build
+
+########################
+### final
+########################
+FROM node:22-slim AS final
+WORKDIR /app
+COPY --from=oauth2proxy /bin/oauth2-proxy /usr/local/bin/oauth2-proxy
+COPY --from=app /app /app/server
+COPY --from=static /site/out /var/www
+
+# Start the Next.js server in the background, then exec oauth2-proxy (the
+# foreground process fronting both the app and the static site as one origin).
+COPY <<'EOF' /usr/local/bin/entrypoint.sh
+#!/bin/sh
+set -e
+APP_PORT="${APP_PORT:-3000}"
+(
+  cd /app/server
+  exec node_modules/.bin/next start -H 0.0.0.0 -p "${APP_PORT}"
+) &
+app_pid=$!
+trap 'kill "${app_pid}" 2>/dev/null || true' TERM INT
+exec oauth2-proxy
+EOF
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ARG APP_ROUTE
+ARG APP_PORT
+ENV NODE_ENV=production
+ENV APP_PORT=${APP_PORT}
+ENV OAUTH2_PROXY_HTTP_ADDRESS=0.0.0.0:8080
+ENV OAUTH2_PROXY_UPSTREAMS=http://127.0.0.1:${APP_PORT}${APP_ROUTE}/,file:///var/www/#/
+ENV OAUTH2_PROXY_REVERSE_PROXY=true
+ENV WEBSITES_PORT=8080
+
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## What

Adds `docker/oauth-next-static` — a canonical Dockerfile for serving a **Next.js app and a static site as one origin behind oauth2-proxy** (Entra sign-in).

A companion to the existing `oauth-static-site` and `oauth-storybook` images. Those front a **static** site only (`OAUTH2_PROXY_UPSTREAMS file:///var/www/#/`); this one adds a **dynamic Next.js server** as a second upstream alongside the static files, for repos that need server-rendered/runtime routes behind auth.

## Generic, like the other oauth-* images

Opinionated about a convention, not any specific app — nothing app-specific is baked in. The consuming repo provides its source as the build context and passes its specifics as **build-args**:

```yaml
build-args: |
  APP_DIR=path/to/next-app   # context-relative dir of the Next.js app (pnpm)
  APP_ROUTE=/app             # the app's basePath / upstream route prefix
  APP_PORT=3000              # port `next start` listens on
```

Conventions the repo follows:
- root `package.json` `npm run build` emits the static site into `./out`
- `APP_DIR` is a self-contained pnpm Next.js app whose next config sets `basePath` to `APP_ROUTE`

Multi-stage: pinned oauth2-proxy binary -> build the Next.js app (`pnpm build`) -> build the static site (`npm run build`) -> final image. The inlined entrypoint starts `next start` in the background, then `exec`s oauth2-proxy as the foreground process. Auth settings (provider/client-id/secret/cookie/email-domains) are applied at deploy time by `oauth-static-site-deploy.yml`, not baked here.

no-work-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)