### PR TITLE
Add canonical oauth-next-static Dockerfile (Next.js app + static behind oauth2-proxy)

### DIFF
--- a/docker/oauth-next-static
+++ b/docker/oauth-next-static
@@ -1,0 +1,83 @@
+# syntax=docker/dockerfile:1
+#
+# oauth-next-static — oauth2-proxy fronting a Next.js app and a static site as one
+# origin. Companion to oauth-static-site / oauth-storybook.
+#
+#   ${APP_ROUTE}*  ->  Next.js server (next start)         :${APP_PORT}
+#   /*             ->  static site (npm run build -> ./out)  /var/www
+#
+# Build-args:
+#   APP_DIR    context-relative dir of the Next.js app (pnpm)
+#   APP_ROUTE  the app's basePath / upstream route prefix
+#   APP_PORT   port next start listens on
+#
+# Contract: root `npm run build` emits ./out; APP_DIR is a self-contained pnpm
+# Next.js app whose config sets basePath to APP_ROUTE. oauth2-proxy auth settings
+# are applied at deploy time, not baked here.
+
+ARG APP_DIR=app
+ARG APP_ROUTE=/app
+ARG APP_PORT=3000
+
+########################
+### oauth2-proxy binary (pinned; bump deliberately)
+########################
+FROM quay.io/oauth2-proxy/oauth2-proxy:v7.15.3 AS oauth2proxy
+
+########################
+### build the Next.js app
+########################
+FROM node:22-slim AS app
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable
+WORKDIR /app
+ARG APP_DIR
+COPY ${APP_DIR}/ ./
+RUN pnpm install --frozen-lockfile
+RUN pnpm build
+
+########################
+### build the static site (-> ./out, served at /var/www)
+########################
+FROM node:22-slim AS static
+WORKDIR /site
+COPY . .
+RUN npm ci --omit=dev
+RUN npm run build
+
+########################
+### final
+########################
+FROM node:22-slim AS final
+WORKDIR /app
+COPY --from=oauth2proxy /bin/oauth2-proxy /usr/local/bin/oauth2-proxy
+COPY --from=app /app /app/server
+COPY --from=static /site/out /var/www
+
+# Run the Next.js server and oauth2-proxy together; forward SIGTERM to both and
+# exit when either does, so the platform restarts the container.
+COPY <<'EOF' /usr/local/bin/entrypoint.sh
+#!/bin/bash
+cd /app/server || exit 1
+node_modules/.bin/next start -H 127.0.0.1 -p "${APP_PORT:-3000}" &
+app=$!
+oauth2-proxy &
+proxy=$!
+trap 'kill -TERM "$app" "$proxy" 2>/dev/null' TERM INT
+wait -n
+kill -TERM "$app" "$proxy" 2>/dev/null
+EOF
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ARG APP_ROUTE
+ARG APP_PORT
+ENV NODE_ENV=production
+ENV APP_PORT=${APP_PORT}
+ENV OAUTH2_PROXY_HTTP_ADDRESS=0.0.0.0:8080
+ENV OAUTH2_PROXY_UPSTREAMS=http://127.0.0.1:${APP_PORT}${APP_ROUTE}/,file:///var/www/#/
+ENV OAUTH2_PROXY_REVERSE_PROXY=true
+ENV WEBSITES_PORT=8080
+
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## What

Adds `docker/oauth-next-static` — a canonical Dockerfile for serving a **Next.js app and a static site as one origin behind oauth2-proxy** (Entra sign-in).

A companion to the existing `oauth-static-site` and `oauth-storybook` images. Those front a **static** site only (`OAUTH2_PROXY_UPSTREAMS file:///var/www/#/`); this one adds a **dynamic Next.js server** as a second upstream alongside the static files, for repos that need server-rendered/runtime routes behind auth.

## Generic, like the other oauth-* images

Opinionated about a convention, not any specific app — nothing app-specific is baked in. The consuming repo provides its source as the build context and passes its specifics as **build-args**:

```yaml
build-args: |
  APP_DIR=path/to/next-app   # context-relative dir of the Next.js app (pnpm)
  APP_ROUTE=/app             # the app's basePath / upstream route prefix
  APP_PORT=3000              # port `next start` listens on
```

Conventions the repo follows:
- root `package.json` `npm run build` emits the static site into `./out`
- `APP_DIR` is a self-contained pnpm Next.js app whose next config sets `basePath` to `APP_ROUTE`

Multi-stage: pinned oauth2-proxy binary (v7.15.3) -> build the Next.js app (`pnpm build`) -> build the static site (`npm run build`) -> final image. The inlined entrypoint runs `next start` (bound to 127.0.0.1) + oauth2-proxy, forwards SIGTERM to both, and exits when either does. Auth settings (provider/client-id/secret/cookie/email-domains) are applied at deploy time by `oauth-static-site-deploy.yml`, not baked here.

## Consumed by

`n3oltd/design` (private) — its CI calls `n3o-docker-build-push.yml` with `dockerfile: oauth-next-static` then `oauth-static-site-deploy.yml`. Merge this first.

no-work-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)