### PR TITLE
oauth-next-static: install ca-certificates (fix oauth2-proxy OIDC TLS failure)

### DIFF
--- a/docker/oauth-next-static
+++ b/docker/oauth-next-static
@@ -50,6 +50,12 @@ RUN npm run build
 ### final
 ########################
 FROM node:22-slim AS final
+# oauth2-proxy is a Go binary and uses the system CA bundle for outbound TLS
+# (OIDC discovery). node:22-slim ships none — Node bundles its own — so add it,
+# else oauth2-proxy dies with "x509: certificate signed by unknown authority".
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=oauth2proxy /bin/oauth2-proxy /usr/local/bin/oauth2-proxy
 COPY --from=app /app /app/server


### PR DESCRIPTION
The `final` stage is `node:22-slim`, which ships **no system CA certificates** (Node bundles its own, so the `npm`/`pnpm` build stages work fine). oauth2-proxy is a **Go** binary and uses the *system* CA bundle for outbound TLS — so it can't validate the connection to the Microsoft OIDC discovery endpoint and dies on startup:

```
ERROR: Failed to initialise OAuth2 Proxy: ... error while discovery OIDC configuration:
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

…which 503s the web app. Found deploying design.n3o.team. Fix: install `ca-certificates` in the final stage.

no-work-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)