### PR TITLE
oauth-static-site / oauth-storybook: pin oauth2-proxy v7.15.3, bump node to 22

### DIFF
--- a/docker/oauth-static-site
+++ b/docker/oauth-static-site
@@ -1,14 +1,14 @@
 ########################
 ### base
 ########################
-FROM quay.io/oauth2-proxy/oauth2-proxy:latest AS base
+FROM quay.io/oauth2-proxy/oauth2-proxy:v7.15.3 AS base
 
 WORKDIR /app
 
 ########################
 ### build
 ########################
-FROM node:18 AS build
+FROM node:22 AS build
 
 WORKDIR /src
 

--- a/docker/oauth-storybook
+++ b/docker/oauth-storybook
@@ -1,14 +1,14 @@
 ########################
 ### base
 ########################
-FROM quay.io/oauth2-proxy/oauth2-proxy:latest AS base
+FROM quay.io/oauth2-proxy/oauth2-proxy:v7.15.3 AS base
 
 WORKDIR /site
 
 ########################
 ### build
 ########################
-FROM node:20 AS build
+FROM node:22 AS build
 
 COPY / /site
 


### PR DESCRIPTION
Follow-up to the ca-certs fix (d8f76a5). Upgrades the other two oauth images:

- **oauth2-proxy** `:latest` → **`:v7.15.3`** (pin to current latest, matching `oauth-next-static` — reproducible builds).
- **Build node** `18`/`20` → **`22`**.

### Do they need the ca-certificates lines? No.
`oauth-next-static` needed them because its `final` stage is `node:22-slim` (no system CA bundle) with just the oauth2-proxy *binary* copied in. These two have `final` as `FROM base` — the **oauth2-proxy image itself** (distroless, already ships CA certs) — so outbound TLS (OIDC discovery) already works. No change needed.

> ⚠️ **Heads-up before merge:** the node bump changes the *build* toolchain for every consumer of these images (e.g. team-site, lib-fe-ui-components on `oauth-static-site`). Worth a quick check that their `yarn`/`npm build` is happy on node 22. The oauth2-proxy pin only affects the runtime image and is safe. Happy to split the node bump out if you'd rather land the pin first.

no-work-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)