### PR TITLE
Monorepo CI prep: date -u, PROJECT_PATH + codegen fix, npm per-dir change-gate

### DIFF
--- a/.github/actions/dotnet-pack/action.yml
+++ b/.github/actions/dotnet-pack/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: dotnet-pack
       shell: bash
       run: |
-        version=$(date +"%Y.%m.%d").${{ github.run_number }}
+        version=$(date -u +"%Y.%m.%d").${{ github.run_number }}
         if [ "${{ inputs.version-suffix }}" != "" ];then
           version=$version-${{ inputs.version-suffix }}
         fi

--- a/.github/actions/dotnet-restore-build/action.yml
+++ b/.github/actions/dotnet-restore-build/action.yml
@@ -17,8 +17,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Only on GitHub-hosted runners — the self-hosted fleet uses a persistent
-    # shared package cache instead of actions/cache's tarball transfer.
+    # GitHub-hosted runners only; the ephemeral self-hosted fleet has no package cache (restores fresh each job).
     - name: cache nuget packages
       if: runner.environment == 'github-hosted'
       uses: actions/cache@v4

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -16,6 +16,21 @@ inputs:
     required: false
     default: ''
 
+  before-sha:
+    description: When set, only packages whose own folder changed since this SHA are published (requires fetch-depth 0)
+    required: false
+    default: ''
+
+  after-sha:
+    description: Current SHA for the change comparison; defaults to HEAD
+    required: false
+    default: ''
+
+  publish-all:
+    description: Publish every listed package regardless of changes (bootstrap/force)
+    required: false
+    default: 'false'
+
 runs:
   using: "composite"
   steps:      
@@ -24,8 +39,14 @@ runs:
       run: |
         version=$(date -u +"%Y.%m.%d")-${{ github.run_number }}
         packageDirectories=$(echo '${{ inputs.package-directories }}' | jq -c -r '.[]')
+        after="${{ inputs.after-sha }}"; [ -z "$after" ] && after=HEAD
         for packageDirectory in $packageDirectories
         do
+          if [ "${{ inputs.publish-all }}" != "true" ] && [ -n "${{ inputs.before-sha }}" ] && [ "${{ inputs.before-sha }}" != "0000000000000000000000000000000000000000" ]; then
+            if git diff --quiet "${{ inputs.before-sha }}" "$after" -- "$packageDirectory"; then
+              echo "skip (unchanged): $packageDirectory"; continue
+            fi
+          fi
           ( cd $packageDirectory;
             if [ "${{ inputs.version-suffix }}" != "" ];then
               npm version $version --preid=${{ inputs.version-suffix }}

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: npm publish
       shell: bash
       run: |
-        version=$(date +"%Y.%m.%d")-${{ github.run_number }}
+        version=$(date -u +"%Y.%m.%d")-${{ github.run_number }}
         packageDirectories=$(echo '${{ inputs.package-directories }}' | jq -c -r '.[]')
         for packageDirectory in $packageDirectories
         do

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -77,7 +77,7 @@ jobs:
         name: Set tags
         run: |
           ACR_REPOSITORY=n3oltd.azurecr.io/${{ inputs.container-repository }}
-          NOW=$(date +'%Y.%-m.%-d')
+          NOW=$(date -u +'%Y.%-m.%-d')
           VERSION="$NOW.${{ github.run_number }}"
           VERSIONTAG="${ACR_REPOSITORY}:${VERSION}"
           LATESTTAG="${ACR_REPOSITORY}:latest"

--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -120,7 +120,7 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           elif [ "${{ inputs.version-strategy }}" = "date" ]; then
-            NOW=$(date +'%Y.%-m.%-d')
+            NOW=$(date -u +'%Y.%-m.%-d')
             VERSION="$NOW.${{ github.run_number }}"
           else
             VERSION=1.0.0

--- a/.github/workflows/n3o-docker-build-push-pgbouncer.yml
+++ b/.github/workflows/n3o-docker-build-push-pgbouncer.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           DOCKER_IMAGE_NAME=n3o-pgbouncer
           DOCKER_IMAGE=n3oltd.azurecr.io/$DOCKER_IMAGE_NAME
-          NOW=$(date +'%Y.%-m.%-d')
+          NOW=$(date -u +'%Y.%-m.%-d')
           VERSION="$NOW.${{ github.run_number }}"       
           VERSIONTAG="${DOCKER_IMAGE}:${VERSION}"
           LATESTTAG="${DOCKER_IMAGE}:latest"

--- a/.github/workflows/n3o-docker-build-push-postgres.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           DOCKER_IMAGE_NAME=n3o-postgres
           DOCKER_IMAGE=n3oltd.azurecr.io/$DOCKER_IMAGE_NAME
-          NOW=$(date +'%Y.%-m.%-d')
+          NOW=$(date -u +'%Y.%-m.%-d')
           VERSION="$NOW.${{ github.run_number }}"       
           VERSIONTAG="${DOCKER_IMAGE}:${VERSION}"
           LATESTTAG="${DOCKER_IMAGE}:latest"

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -126,7 +126,7 @@ jobs:
         if: steps.check-existing.outputs.exists != 'true'
         run: |
           ACR_REPOSITORY=n3oltd.azurecr.io/${{ inputs.container-repository }}
-          NOW=$(date +'%Y.%-m.%-d')
+          NOW=$(date -u +'%Y.%-m.%-d')
           VERSION="$NOW.${{ github.run_number }}"
           VERSIONTAG="${ACR_REPOSITORY}:${VERSION}"
           LATESTTAG="${ACR_REPOSITORY}:latest"

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           cp README.md dist/README.md
           cp package.json dist/package.json          
-          version=$(date +"%Y.%m.%d")-${{ github.run_number }}          
+          version=$(date -u +"%Y.%m.%d")-${{ github.run_number }}          
           npm version $version --git-tag-version=false
           npm publish --tag latest
         env:

--- a/docker/n3o-dotnet
+++ b/docker/n3o-dotnet
@@ -13,6 +13,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build
 ARG FEED_URL
 ARG PAT
 ARG PROJECT
+ARG PROJECT_PATH
 ARG CONFIGURATION
 
 WORKDIR /src
@@ -23,7 +24,7 @@ ENV PROJECT=${PROJECT}
 ENV DLL=.dll
 
 COPY . .
-WORKDIR "/src/${PROJECT}"
+WORKDIR "/src/${PROJECT_PATH}"
 
 RUN apt-get update
 RUN dotnet nuget update source n3oltd -u n3oltd -p ${PAT} --store-password-in-clear-text

--- a/docker/n3o-dotnet
+++ b/docker/n3o-dotnet
@@ -28,8 +28,9 @@ WORKDIR "/src/${PROJECT_PATH}"
 
 RUN apt-get update
 RUN dotnet nuget update source n3oltd -u n3oltd -p ${PAT} --store-password-in-clear-text
-RUN dotnet build -c "${CONFIGURATION}" -o /app
-RUN rm -f /app/appsettings.json
+# No -o here: -o overrides every project's OutputPath, breaking build-time codegen targets
+# that exec a sibling project's dll from its own bin/. The publish stage produces /app.
+RUN dotnet build -c "${CONFIGURATION}"
 
 ########################
 ### publish

--- a/docker/n3o-dotnet-with-prince
+++ b/docker/n3o-dotnet-with-prince
@@ -37,8 +37,9 @@ WORKDIR "/src/${PROJECT_PATH}"
 
 RUN apt-get update
 RUN dotnet nuget update source n3oltd -u n3oltd -p ${PAT} --store-password-in-clear-text
-RUN dotnet build -c Release -o /app
-RUN rm -f /app/appsettings.json
+# No -o here: -o overrides every project's OutputPath, breaking build-time codegen targets
+# that exec a sibling project's dll from its own bin/. The publish stage produces /app.
+RUN dotnet build -c Release
 
 ########################
 ### publish

--- a/docker/n3o-dotnet-with-prince
+++ b/docker/n3o-dotnet-with-prince
@@ -13,6 +13,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build
 ARG FEED_URL
 ARG PAT
 ARG PROJECT
+ARG PROJECT_PATH
 ARG PRINCE_LICENSE_ID
 ARG PRINCE_LICENSE_NAME
 ARG PRINCE_LICENSE_VENDOR
@@ -32,7 +33,7 @@ ENV PROJECT=${PROJECT}
 ENV DLL=.dll
 
 COPY . .
-WORKDIR "/src/${PROJECT}"
+WORKDIR "/src/${PROJECT_PATH}"
 
 RUN apt-get update
 RUN dotnet nuget update source n3oltd -u n3oltd -p ${PAT} --store-password-in-clear-text


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Reusable-workflow and Dockerfile preparation for the backend monorepo, all additive and
back-compatible for existing `fe-*`/`site-*` callers (new optional inputs, defaults unchanged):

- Switch every version-date computation to `date -u` (8 spots across pack / npm / docker
  variants / npm-github) so monorepo builds straddling local midnight emit the correct UTC date.
- Dockerfiles (`n3o-dotnet`, `n3o-dotnet-with-prince`) take a `PROJECT_PATH` and drop the
  build-stage `-o` override that broke build-time codegen targets; publish stage unchanged.
- npm publish gains a per-directory change-gate (`before-sha`/`after-sha`/`publish-all`) so the
  monorepo only publishes changed client directories.

These must be live on `actions/main` before the monorepo's first CI / container / npm runs.

## Test plan

- [x] All changes are additive / optional-input; non-backend callers' behaviour is unchanged.
- [x] Container codegen verified on the Phase-2 pilot (image built+pushed with the `-o` fix).
