### PR TITLE
n3o-cli-install: add n3oltd source only if not already present

### DIFF
--- a/.github/actions/n3o-cli-install/action.yml
+++ b/.github/actions/n3o-cli-install/action.yml
@@ -20,11 +20,18 @@ runs:
   steps:
     - name: dotnet tool install n3o
       env:
+        GH_USERNAME: n3oltd
+        GH_PAT: ${{ inputs.access-token }}
         AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
         AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
         AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}
       shell: bash
       run: |
-        dotnet nuget add source https://nuget.pkg.github.com/n3oltd/index.json --name n3oltd --username n3oltd --password ${{ inputs.access-token }} --store-password-in-clear-text
+        # Add the n3oltd feed only if it isn't already configured (a repo nuget.config may define it,
+        # in which case adding it again would fail). GH_USERNAME/GH_PAT are in the env either way so a
+        # config that references %GH_USERNAME%/%GH_PAT% can authenticate.
+        if ! dotnet nuget list source 2>/dev/null | grep -qi 'nuget.pkg.github.com/n3oltd'; then
+          dotnet nuget add source https://nuget.pkg.github.com/n3oltd/index.json --name n3oltd --username "$GH_USERNAME" --password "$GH_PAT" --store-password-in-clear-text
+        fi
         dotnet tool install --global --no-cache n3o
         echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"

--- a/.github/actions/n3o-cli-install/action.yml
+++ b/.github/actions/n3o-cli-install/action.yml
@@ -27,9 +27,6 @@ runs:
         AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}
       shell: bash
       run: |
-        # Add the n3oltd feed only if it isn't already configured (a repo nuget.config may define it,
-        # in which case adding it again would fail). GH_USERNAME/GH_PAT are in the env either way so a
-        # config that references %GH_USERNAME%/%GH_PAT% can authenticate.
         if ! dotnet nuget list source 2>/dev/null | grep -qi 'nuget.pkg.github.com/n3oltd'; then
           dotnet nuget add source https://nuget.pkg.github.com/n3oltd/index.json --name n3oltd --username "$GH_USERNAME" --password "$GH_PAT" --store-password-in-clear-text
         fi


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

`n3o-cli-install` ran `dotnet nuget add source --name n3oltd …` unconditionally, which fails with
"The name specified has already been added" when the consumer's `nuget.config` already defines the
n3oltd feed. The backend monorepo now configures that feed (scoped to the `n3o` tool), so make the
add idempotent: add the source only if it isn't already configured. `GH_USERNAME`/`GH_PAT` are set
in the step env so a config that references `%GH_USERNAME%`/`%GH_PAT%` authenticates on the
skip path; the add path is unchanged for repos that don't define the feed (fe/site repos).

## Test plan

- [x] Backend monorepo (feed in nuget.config): add is skipped, `dotnet tool install n3o` resolves
      from the configured feed.
- [x] Repos without the feed: add runs as before.
