### PR TITLE
Add n3o-dotnet-affected-build composite (centralise monorepo affected build)

### DIFF
--- a/.github/actions/n3o-dotnet-cli-setup/action.yml
+++ b/.github/actions/n3o-dotnet-cli-setup/action.yml
@@ -1,6 +1,6 @@
 name: n3o dotnet + cli setup
 description: >
-  Sets up the .NET SDK and installs the n3o CLI in one step. Bundles actions/setup-dotnet
+  Sets up the .NET SDK and installs the n3o CLI in one step. Bundles n3o-dotnet-setup
   followed by n3o-cli-install (which the CLI's dotnet tool install requires). Azure inputs
   are optional for callers that only need the nuget source token.
 
@@ -28,8 +28,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Detects the baked SDK and skips the download itself.
-    - uses: actions/setup-dotnet@v5
+    - uses: n3oltd/actions/.github/actions/n3o-dotnet-setup@main
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 

--- a/.github/actions/n3o-dotnet-setup/action.yml
+++ b/.github/actions/n3o-dotnet-setup/action.yml
@@ -1,0 +1,15 @@
+name: n3o dotnet setup
+description: Central .NET SDK setup (setup-dotnet@v5 — skips the install when the SDK is baked into the runner).
+
+inputs:
+  dotnet-version:
+    description: .NET SDK version to install
+    required: false
+    default: '10.x'
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}

--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v5
+      - uses: n3oltd/actions/.github/actions/n3o-dotnet-setup@main
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 

--- a/.github/workflows/n3o-dotnet-affected-build.yml
+++ b/.github/workflows/n3o-dotnet-affected-build.yml
@@ -1,0 +1,68 @@
+# Reusable workflow: build only the projects affected between two commits (and their dependents).
+name: dotnet affected build
+
+on:
+  workflow_call:
+    inputs:
+      from:
+        description: Base commit to diff from; empty / zero-sha falls back to <to>~1.
+        type: string
+        default: ''
+      to:
+        description: Head commit to diff to.
+        type: string
+        required: true
+      build-configuration:
+        type: string
+        default: Release
+      mode:
+        description: "wait (self-hosted, free, queued) or fast (GitHub-hosted, billable). A [ci fast] commit marker forces fast."
+        type: string
+        default: wait
+
+jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    with:
+      mode: ${{ contains(github.event.head_commit.message, '[ci fast]') && 'fast' || inputs.mode }}
+    secrets: inherit
+
+  build:
+    needs: pick
+    runs-on: ${{ needs.pick.outputs.runs-on }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # dotnet-affected diffs from..to; needs full history
+          filter: blob:none
+
+      - uses: n3oltd/actions/.github/actions/n3o-dotnet-setup@main
+
+      - name: install dotnet-affected
+        shell: bash
+        run: |
+          dotnet tool install --global dotnet-affected
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: compute affected
+        id: affected
+        shell: bash
+        env:
+          FROM_SHA: ${{ inputs.from }}
+          TO_SHA: ${{ inputs.to }}
+        run: |
+          base="$FROM_SHA"
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then base="${TO_SHA}~1"; fi
+          if dotnet affected --from "$base" --to "$TO_SHA" --format traversal --output-dir "$RUNNER_TEMP" --output-name affected; then
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=false" >> "$GITHUB_OUTPUT"   # the tool exits non-zero when nothing is affected
+          fi
+
+      - name: build affected
+        if: steps.affected.outputs.any == 'true'
+        shell: bash
+        env:
+          GH_USERNAME: n3oltd
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: dotnet build "$RUNNER_TEMP/affected.proj" -c "${{ inputs.build-configuration }}"

--- a/.github/workflows/n3o-dotnet-build.yml
+++ b/.github/workflows/n3o-dotnet-build.yml
@@ -43,10 +43,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v6
 
-      - name: setup-dotnet
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.x'
+      - uses: n3oltd/actions/.github/actions/n3o-dotnet-setup@main
 
       - name: dotnet build
         uses: n3oltd/actions/.github/actions/dotnet-restore-build@main


### PR DESCRIPTION
Adds a composite action that centralises the backend monorepo's **affected-solution build** — the one CI behaviour the actions repo didn't yet have, so it had been inlined in `backend/.github/workflows/ci.yml` with `actions/setup-dotnet@v4` (which fails on the self-hosted fleet: `Permission denied` writing to root-owned `/usr/share/dotnet`).

Steps: `setup-dotnet@v5` (detects the baked SDK, skips install on self-hosted) → nuget cache (hosted only) → `dotnet tool restore` → `dotnet affected --from --to` → build **only** `affected.proj` (nothing when nothing's affected). Inputs: `from`/`to` (zero-sha falls back to `<to>~1`), `build-configuration`, `access-token`, `dotnet-version`.

Paired with a backend PR that swaps the inline steps in `ci.yml`/`pr.yml` for `uses: n3oltd/actions/.github/actions/n3o-dotnet-affected-build@main`. Merge this first so the `@main` ref resolves.

no-work-issue (CI centralisation)