### PR TITLE
Add n3o-build-paths-changed composite (wrap dorny/paths-filter)

### DIFF
--- a/.github/actions/n3o-build-paths-changed/action.yml
+++ b/.github/actions/n3o-build-paths-changed/action.yml
@@ -1,0 +1,22 @@
+name: n3o build paths changed
+description: Coarse CI pre-gate — true when any build-relevant path changed (src, CPM props, global.json, nuget.config).
+
+outputs:
+  changed:
+    description: "'true' when a build-relevant path changed"
+    value: ${{ steps.filter.outputs.build }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          build:
+            - 'src/**'
+            - 'Directory.Build.props'
+            - 'Directory.Packages.props'
+            - 'global.json'
+            - 'nuget.config'


### PR DESCRIPTION
Wraps `dorny/paths-filter` so the backend monorepo's `main-ci`/`main-pr` carry **no third-party action inline** — the last bit of CI centralisation. Bakes the build-relevant path set; outputs `changed`.

Paired with a backend change pointing the `changes` job at `n3o-build-paths-changed@main`.

no-work-issue (CI centralisation)