### PR TITLE
n3o-dotnet-affected-build: expose affected-projects output

### DIFF
--- a/.github/workflows/n3o-dotnet-affected-build.yml
+++ b/.github/workflows/n3o-dotnet-affected-build.yml
@@ -19,6 +19,10 @@ on:
         description: "wait (self-hosted, free, queued) or fast (GitHub-hosted, billable). A [ci fast] commit marker forces fast."
         type: string
         default: wait
+    outputs:
+      affected-projects:
+        description: "JSON array of affected project names (.csproj basenames, incl. dependents); '[]' when none."
+        value: ${{ jobs.build.outputs.affected-projects }}
 
 jobs:
   pick:
@@ -30,6 +34,8 @@ jobs:
   build:
     needs: pick
     runs-on: ${{ needs.pick.outputs.runs-on }}
+    outputs:
+      affected-projects: ${{ steps.affected.outputs.projects }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -55,9 +61,17 @@ jobs:
           if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then base="${TO_SHA}~1"; fi
           if dotnet affected --from "$base" --to "$TO_SHA" --format traversal --output-dir "$RUNNER_TEMP" --output-name affected; then
             echo "any=true" >> "$GITHUB_OUTPUT"
+            # The traversal project lists every affected project (changed + dependents) as
+            # <ProjectReference Include="…/Name.csproj" />; expose their basenames so a caller can
+            # gate downstream work on a specific project being affected.
+            projects="$(grep -oE 'Include="[^"]+\.csproj"' "$RUNNER_TEMP/affected.proj" \
+              | sed -E 's/.*[\/\\]//; s/\.csproj"$//' \
+              | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')"
           else
             echo "any=false" >> "$GITHUB_OUTPUT"   # the tool exits non-zero when nothing is affected
+            projects='[]'
           fi
+          echo "projects=$projects" >> "$GITHUB_OUTPUT"
 
       - name: build affected
         if: steps.affected.outputs.any == 'true'


### PR DESCRIPTION
## Summary

The reusable `n3o-dotnet-affected-build.yml` workflow already computes the affected project set (changed projects **plus their dependents**) to drive the build, but kept it internal. This exposes it as a workflow output:

- `affected-projects` — a JSON array of affected `.csproj` basenames (e.g. `["N3O.Framework","N3O.Cli.Application"]`), `[]` when nothing is affected.

Derived by parsing the `<ProjectReference Include="…/Name.csproj" />` entries of the traversal project dotnet-affected already emits (handles both `/` and `\\` separators; deduped). No extra tool invocation; `jq` is already on the runner fleet.

This lets a **caller** gate downstream work on a specific project being affected while keeping this workflow generic — it has no knowledge of any particular project. First consumer: backend's `publish-n3o` (republishes the {n3o} CLI only when `N3O.Cli.Application` is affected, instead of on a `src/cli/**` path glob that misses libraries the CLI depends on).

Backward-compatible: existing callers (`main-pr.yml`, `main-ci.yml`) ignore the new output.

re n3oltd/work#2766

## Test plan

- [ ] Merge this **before** the backend consumer PR (the backend `if:` is guarded against an empty output, so a wrong order is safe, just leaves the CLI ungated until merged).
- [ ] First real `src/`-touching merge on backend: confirm the `build` job's `affected-projects` output is populated (visible in the job summary / consumed by `publish-n3o`).
- [ ] Verify a no-affected push yields `[]` and downstream gates skip cleanly.