### PR TITLE
Deploy oauth-static sites by immutable sha tag (fix stale :latest cache)

### DIFF
--- a/.github/workflows/oauth-static-site-deploy.yml
+++ b/.github/workflows/oauth-static-site-deploy.yml
@@ -82,7 +82,7 @@ jobs:
           client_id: "${{ inputs.client-id }}"
           client_secret: "${{ secrets.client-secret }}"
           cookie_secret: "${{ secrets.cookie-secret }}"
-          custom_image: "n3oltd.azurecr.io/${{ inputs.docker-image }}:latest"
+          custom_image: "n3oltd.azurecr.io/${{ inputs.docker-image }}:sha-${{ github.sha }}"
           email_domains: "${{ inputs.email-domains }}"
           resource_group: "${{ inputs.resource-group }}"
           tenant_id: "${{ inputs.tenant-id }}"


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Static sites on the `oauth-static-site-deploy` workflow (design.n3o.team, team-site, fe-platforms, lib-fe-ui-components) could deploy successfully yet keep serving stale content. Azure App Service caches a container image by its **tag string**, so the existing `az webapp config container set …:latest` + `az webapp restart` can silently re-run the already-cached `:latest` image — the new image is in ACR, but the running container never changes. This bit a `design.n3o.team` deploy: CI was green, the image (with the new content) was pushed, but the site didn't update.

The fix pins the web app to the **immutable per-commit tag** `n3oltd.azurecr.io/<image>:sha-<github.sha>` instead of `:latest`. The `n3o-docker-build-push` workflow tags every image with `:sha-<commit>` and guarantees its presence (its build-skip existence check keys on that exact tag), and `github.sha` is identical across the build and deploy jobs of a run. Because the image reference string now changes on every deploy, App Service is forced to pull the new image. `:latest` is still pushed by build-push — it's just no longer what the deploy references.

This is a single shared-workflow change that fixes every site using it, with no per-app webhooks and no caller changes.

## Test plan

- [ ] Merge, then trigger a deploy on a consumer (e.g. push to `n3oltd/design` `main`)
- [ ] Deploy job's `az webapp config container set` shows `…:sha-<commit>` (not `:latest`)
- [ ] The live site reflects the new commit after the run completes (no manual restart / digest-pin needed)
- [ ] App Service container config (`az webapp config container show`) shows the sha tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
