### PR TITLE
umbraco13: support PROJECT_PATH for monorepo builds

### DIFF
--- a/docker/umbraco13
+++ b/docker/umbraco13
@@ -11,6 +11,7 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0-noble AS build
 
 ARG PROJECT
+ARG PROJECT_PATH
 ARG VERSION
 ARG SOURCE_REVISION_ID
 
@@ -19,9 +20,12 @@ WORKDIR /src
 ENV PROJECT=${PROJECT}
 
 COPY . .
-WORKDIR "/src/${PROJECT}"
 
-RUN dotnet build --configuration Release --output /build /p:Version=${VERSION} /p:SourceRevisionId=${SOURCE_REVISION_ID}
+# Monorepo callers build with the repo root as the context and pass PROJECT_PATH (the project
+# directory, context-relative); single-repo callers build with the project's parent as the context
+# and pass PROJECT only, so PROJECT_PATH defaults to PROJECT.
+RUN cd "/src/${PROJECT_PATH:-$PROJECT}" \
+ && dotnet build --configuration Release --output /build /p:Version=${VERSION} /p:SourceRevisionId=${SOURCE_REVISION_ID}
 
 ########################
 ### publish
@@ -29,10 +33,12 @@ RUN dotnet build --configuration Release --output /build /p:Version=${VERSION} /
 FROM build AS publish
 
 ARG PROJECT
+ARG PROJECT_PATH
 ARG VERSION
 ARG SOURCE_REVISION_ID
 
-RUN dotnet publish "${PROJECT}.csproj" --configuration Release --output /publish /p:Version=${VERSION} /p:SourceRevisionId=${SOURCE_REVISION_ID}
+RUN cd "/src/${PROJECT_PATH:-$PROJECT}" \
+ && dotnet publish "${PROJECT}.csproj" --configuration Release --output /publish /p:Version=${VERSION} /p:SourceRevisionId=${SOURCE_REVISION_ID}
 
 ########################
 ### final


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2770

## Summary

Prepares the `umbraco13` Dockerfile for the `n3oltd/sites` monorepo, which builds each site image with the **repo root** as the Docker context (so cross-cutting monorepo files are available and the site's project sits at a monorepo-relative path) and calls `n3o-docker-build-push.yml` with a `PROJECT_PATH` build-arg — exactly as `n3o-dotnet` does for backend services.

Adds an optional `PROJECT_PATH` arg to the build + publish stages. The working directory is now `/src/${PROJECT_PATH:-$PROJECT}`, so:
- **monorepo callers** pass `PROJECT_PATH` (e.g. `src/site-mh/src/MuslimHands.Web`) with the repo root as context;
- **single-repo callers** (e.g. the still-live `site-mh-intranet`, which builds via the legacy `docker-build-push.yml` with the project's parent as context and `PROJECT` only) are **unchanged** — `PROJECT_PATH` defaults to `PROJECT`.

Fully backward-compatible; no existing caller changes behaviour.

## Test plan

- [x] Diff is additive (`PROJECT_PATH` arg + `cd "/src/${PROJECT_PATH:-$PROJECT}"`); legacy path (`PROJECT_PATH` unset → `PROJECT`) preserved.
- [ ] Sites monorepo pilot image build (`containers=site-mth`) produces a working image.