### PR TITLE
Affected build: full-build fallback on structural changes

### DIFF
--- a/.github/workflows/n3o-dotnet-affected-build.yml
+++ b/.github/workflows/n3o-dotnet-affected-build.yml
@@ -59,7 +59,21 @@ jobs:
         run: |
           base="$FROM_SHA"
           if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then base="${TO_SHA}~1"; fi
-          if dotnet affected --from "$base" --to "$TO_SHA" --format traversal --output-dir "$RUNNER_TEMP" --output-name affected; then
+
+          # dotnet-affected diffs the project graph between two commits, but a STRUCTURAL change is
+          # not reliably traced: a new/removed project, a changed ProjectReference, or a build-config
+          # file (props/slnx/global.json/nuget.config/lock). A new project's dependency edge into an
+          # existing project can be missed, so an existing project that should rebuild doesn't — the
+          # affected set under-builds. When the diff touches any such file, build EVERYTHING and
+          # report every project affected. Routine source changes keep the fast affected path.
+          structural='(\.csproj$|\.slnx?$|(^|/)Directory\.[A-Za-z]+\.props$|(^|/)global\.json$|(^|/)nuget\.config$|(^|/)packages\.lock\.json$)'
+          if git diff --name-only "$base" "$TO_SHA" | grep -qiE "$structural"; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            echo "any=true" >> "$GITHUB_OUTPUT"
+            projects="$(find . -name '*.csproj' -not -path '*/bin/*' -not -path '*/obj/*' \
+              | sed -E 's#.*/##; s/\.csproj$//' | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')"
+          elif dotnet affected --from "$base" --to "$TO_SHA" --format traversal --output-dir "$RUNNER_TEMP" --output-name affected; then
+            echo "full=false" >> "$GITHUB_OUTPUT"
             echo "any=true" >> "$GITHUB_OUTPUT"
             # The traversal project lists every affected project (changed + dependents) as
             # <ProjectReference Include="…/Name.csproj" />; expose their basenames so a caller can
@@ -68,6 +82,7 @@ jobs:
               | sed -E 's/.*[\/\\]//; s/\.csproj"$//' \
               | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')"
           else
+            echo "full=false" >> "$GITHUB_OUTPUT"
             echo "any=false" >> "$GITHUB_OUTPUT"   # the tool exits non-zero when nothing is affected
             projects='[]'
           fi
@@ -79,4 +94,9 @@ jobs:
         env:
           GH_USERNAME: n3oltd
           GH_PAT: ${{ secrets.GH_PAT }}
-        run: dotnet build "$RUNNER_TEMP/affected.proj" -c "${{ inputs.build-configuration }}"
+        run: |
+          if [ "${{ steps.affected.outputs.full }}" = "true" ]; then
+            dotnet build -c "${{ inputs.build-configuration }}"   # full solution — structural change
+          else
+            dotnet build "$RUNNER_TEMP/affected.proj" -c "${{ inputs.build-configuration }}"
+          fi


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2770

## Summary

`n3o-dotnet-affected-build` uses `dotnet affected` to build only the projects changed between two commits (plus dependents). That's correct for routine source edits, but `dotnet-affected` **does not reliably trace a structural change** — a new or removed project, a changed `ProjectReference`, or a build-config file (`Directory.*.props`, `*.slnx`, `global.json`, `nuget.config`, `packages.lock.json`).

The concrete failure that surfaced this: a new project was added and an existing project (`N3O.Cli.Application`) gained a reference to it; that new dependency edge wasn't traced, so `Application` wasn't marked affected and didn't rebuild. The same class of miss could let a real break (an existing project failing against a newly-changed dependency) slip through CI silently.

Fix: when the `from..to` diff touches any structural file, **build the full solution and report every project as affected**. Routine `.cs`/source changes are unaffected and keep the fast `dotnet-affected` path.

This is the generic root fix; the `publish-cli` symptom in backend `main-ci` is addressed separately (path-gated tool republish).

## Test plan

- [x] Structural diff (csproj/slnx/props/global.json/nuget.config/lock) → `full=true` → `dotnet build` of the solution + all project basenames in `affected-projects`.
- [x] Source-only diff → unchanged `dotnet affected` path.
- [ ] Verify on a structural-change push to backend that the full build runs and `affected-projects` lists everything.