### PR TITLE
Mirror: pass the SSH key via env (fix multi-line key)

### DIFF
--- a/.github/workflows/n3o-mirror-subtree.yml
+++ b/.github/workflows/n3o-mirror-subtree.yml
@@ -42,9 +42,11 @@ jobs:
           fetch-depth: 0   # full history is required for the subtree split
 
       - name: configure ssh
+        env:
+          SSH_KEY: ${{ secrets.ssh-key }}   # via env: a multi-line key inlined into the script breaks it
         run: |
           mkdir -p ~/.ssh
-          printf '%s\n' "${{ secrets.ssh-key }}" > ~/.ssh/id_mirror
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_mirror
           chmod 600 ~/.ssh/id_mirror
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
 


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2770

## Summary

`n3o-mirror-subtree.yml` wrote the deploy key with `printf '%s\n' "${{ secrets.ssh-key }}"` — interpolating the secret **directly into the script**. A multi-line key splits the script across lines, so the key body lines run as shell commands (the job failed at `configure ssh` with exit 127). Pass the key through `env:` instead (`printf '%s\n' "$SSH_KEY"`), which is multi-line-safe.

Surfaced on the first real `site-mh` mirror run; the gh-pages publish (s0 action, which takes the key via env) succeeded with the same secret, confirming the key itself is fine.

## Test plan

- [x] Key now via `env: SSH_KEY`; `printf '%s\n' "$SSH_KEY"` writes it intact.
- [ ] Re-run the site-mh mirror after merge → subtree split + force-push to muslimhands/website succeeds.