### PR TITLE
Mirror: run on ubuntu-latest (self-hosted lacks ssh-keyscan)

### DIFF
--- a/.github/workflows/n3o-mirror-subtree.yml
+++ b/.github/workflows/n3o-mirror-subtree.yml
@@ -34,7 +34,9 @@ permissions:
 
 jobs:
   mirror:
-    runs-on: ${{ github.event.repository.private && 'n3o-github-runner' || 'ubuntu-latest' }}
+    # A lightweight git+ssh op — needs standard ssh tooling (ssh-keyscan), which the self-hosted
+    # fleet doesn't carry, so run on the hosted runner.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2770

## Summary

The first real `site-mh` mirror failed at `configure ssh` with exit 127 — `ssh-keyscan: command not found`. The job ran on the self-hosted fleet (`n3o-github-runner`, because the sites repo is private), which doesn't carry the standard ssh tooling. The mirror is a lightweight `git subtree split` + force-push, so run it on `ubuntu-latest` (the per-repo mirror it replaces did the same). gh-pages already publishes from `ubuntu-latest` and worked.

## Test plan

- [x] `runs-on: ubuntu-latest` (was the private→self-hosted conditional).
- [ ] Re-run the site-mh mirror after merge → subtree force-push to muslimhands/website succeeds.