### PR TITLE
Revert #136 (full-build on structural change is too heavy)

### DIFF
--- a/.github/workflows/n3o-dotnet-affected-build.yml
+++ b/.github/workflows/n3o-dotnet-affected-build.yml
@@ -59,21 +59,7 @@ jobs:
         run: |
           base="$FROM_SHA"
           if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then base="${TO_SHA}~1"; fi
-
-          # dotnet-affected diffs the project graph between two commits, but a STRUCTURAL change is
-          # not reliably traced: a new/removed project, a changed ProjectReference, or a build-config
-          # file (props/slnx/global.json/nuget.config/lock). A new project's dependency edge into an
-          # existing project can be missed, so an existing project that should rebuild doesn't — the
-          # affected set under-builds. When the diff touches any such file, build EVERYTHING and
-          # report every project affected. Routine source changes keep the fast affected path.
-          structural='(\.csproj$|\.slnx?$|(^|/)Directory\.[A-Za-z]+\.props$|(^|/)global\.json$|(^|/)nuget\.config$|(^|/)packages\.lock\.json$)'
-          if git diff --name-only "$base" "$TO_SHA" | grep -qiE "$structural"; then
-            echo "full=true" >> "$GITHUB_OUTPUT"
-            echo "any=true" >> "$GITHUB_OUTPUT"
-            projects="$(find . -name '*.csproj' -not -path '*/bin/*' -not -path '*/obj/*' \
-              | sed -E 's#.*/##; s/\.csproj$//' | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')"
-          elif dotnet affected --from "$base" --to "$TO_SHA" --format traversal --output-dir "$RUNNER_TEMP" --output-name affected; then
-            echo "full=false" >> "$GITHUB_OUTPUT"
+          if dotnet affected --from "$base" --to "$TO_SHA" --format traversal --output-dir "$RUNNER_TEMP" --output-name affected; then
             echo "any=true" >> "$GITHUB_OUTPUT"
             # The traversal project lists every affected project (changed + dependents) as
             # <ProjectReference Include="…/Name.csproj" />; expose their basenames so a caller can
@@ -82,7 +68,6 @@ jobs:
               | sed -E 's/.*[\/\\]//; s/\.csproj"$//' \
               | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')"
           else
-            echo "full=false" >> "$GITHUB_OUTPUT"
             echo "any=false" >> "$GITHUB_OUTPUT"   # the tool exits non-zero when nothing is affected
             projects='[]'
           fi
@@ -94,9 +79,4 @@ jobs:
         env:
           GH_USERNAME: n3oltd
           GH_PAT: ${{ secrets.GH_PAT }}
-        run: |
-          if [ "${{ steps.affected.outputs.full }}" = "true" ]; then
-            dotnet build -c "${{ inputs.build-configuration }}"   # full solution — structural change
-          else
-            dotnet build "$RUNNER_TEMP/affected.proj" -c "${{ inputs.build-configuration }}"
-          fi
+        run: dotnet build "$RUNNER_TEMP/affected.proj" -c "${{ inputs.build-configuration }}"


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2770

## Summary

Reverts #136. The full-build-on-structural-change fallback builds the entire solution (~900 projects in the backend monorepo); on the self-hosted fleet that ran ~16 min and the runner died mid-build (no step conclusion — OOM/eviction), failing `main-ci`'s `build` job and blocking the `{n3o}` tool republish. A heavyweight full build on every csproj/props/slnx change is not viable here.

Restores the affected-only build (the long-standing behaviour). The real affected-detection blind spot (a brand-new project's dependency edge not traced) will be fixed properly with a **light, targeted** approach — build the affected set **∪ the directly-changed `.csproj` projects** from the diff, never the full solution — as a separate, fleet-tested PR.

## Test plan

- [x] `n3o-dotnet-affected-build` back to `dotnet affected` → `dotnet build affected.proj` only.
- [ ] Re-run backend main-ci → affected build completes → publish-cli republishes {n3o}.