### PR TITLE
umbraco13: default VERSION (build works without a VERSION build-arg)

### DIFF
--- a/docker/umbraco13
+++ b/docker/umbraco13
@@ -25,7 +25,7 @@ COPY . .
 # directory, context-relative); single-repo callers build with the project's parent as the context
 # and pass PROJECT only, so PROJECT_PATH defaults to PROJECT.
 RUN cd "/src/${PROJECT_PATH:-$PROJECT}" \
- && dotnet build --configuration Release --output /build /p:Version=${VERSION} /p:SourceRevisionId=${SOURCE_REVISION_ID}
+ && dotnet build --configuration Release --output /build /p:Version=${VERSION:-1.0.0} /p:SourceRevisionId=${SOURCE_REVISION_ID}
 
 ########################
 ### publish
@@ -38,7 +38,7 @@ ARG VERSION
 ARG SOURCE_REVISION_ID
 
 RUN cd "/src/${PROJECT_PATH:-$PROJECT}" \
- && dotnet publish "${PROJECT}.csproj" --configuration Release --output /publish /p:Version=${VERSION} /p:SourceRevisionId=${SOURCE_REVISION_ID}
+ && dotnet publish "${PROJECT}.csproj" --configuration Release --output /publish /p:Version=${VERSION:-1.0.0} /p:SourceRevisionId=${SOURCE_REVISION_ID}
 
 ########################
 ### final


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2770

## Summary

The `site-mth` pilot got all the way through the `umbraco13` image build — `PROJECT_PATH` resolved, myget restore succeeded — and failed compiling with `MSB4044: GetAssemblyVersion … required parameter "NuGetVersion"`. Cause: the Dockerfile runs `dotnet build /p:Version=${VERSION}`, but the **new** `n3o-docker-build-push` workflow (which the sites monorepo uses) doesn't pass a `VERSION` build-arg (the legacy `docker-build-push` did), so `Version` was empty and the SDK couldn't derive a package version.

Default it: `/p:Version=${VERSION:-1.0.0}` (build + publish). Single-repo callers that still pass `VERSION` use theirs; monorepo builds get `1.0.0` baked into the assembly (the **image tag** carries the real CalVer version, same as backend services). 

## Test plan

- [x] `/p:Version=${VERSION:-1.0.0}` in both build + publish stages.
- [ ] Re-run the site-mth pilot → image builds and pushes to ACR.