### PR TITLE
fix(ci): guard no-match greps in dotnet-affected build step

### DIFF
--- a/.github/workflows/n3o-dotnet-affected-build.yml
+++ b/.github/workflows/n3o-dotnet-affected-build.yml
@@ -81,8 +81,10 @@ jobs:
           # so the build step also builds the directly-changed .csproj explicitly (changed-csprojs).
           dotnet affected --from "$base" --to "$TO_SHA" --format traversal --output-dir "$RUNNER_TEMP" --output-name affected || true
 
+          # GitHub runs steps with `bash -e -o pipefail`, so a grep that matches nothing (exit 1)
+          # aborts the step. Guard each grep that may legitimately find nothing with `|| true`.
           : > "$RUNNER_TEMP/changed-csprojs.txt"
-          printf '%s\n' "$changed" | grep -E '\.csproj$' | while read -r c; do
+          printf '%s\n' "$changed" | { grep -E '\.csproj$' || true; } | while read -r c; do
             [ -f "$c" ] && printf '%s\n' "$(cd "$(dirname "$c")" && pwd)/$(basename "$c")" >> "$RUNNER_TEMP/changed-csprojs.txt"
           done
 
@@ -93,9 +95,9 @@ jobs:
           fi
 
           aff=''
-          [ -f "$RUNNER_TEMP/affected.proj" ] && aff="$(grep -oE 'Include="[^"]+\.csproj"' "$RUNNER_TEMP/affected.proj" | sed -E 's/.*[\/\\]//; s/\.csproj"$//')"
+          [ -f "$RUNNER_TEMP/affected.proj" ] && aff="$({ grep -oE 'Include="[^"]+\.csproj"' "$RUNNER_TEMP/affected.proj" || true; } | sed -E 's/.*[\/\\]//; s/\.csproj"$//')"
           chg="$(sed -E 's#.*/##; s/\.csproj$//' "$RUNNER_TEMP/changed-csprojs.txt" 2>/dev/null)"
-          projects="$(printf '%s\n%s\n' "$aff" "$chg" | grep -v '^$' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')"
+          projects="$(printf '%s\n%s\n' "$aff" "$chg" | { grep -v '^$' || true; } | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')"
           echo "projects=$projects" >> "$GITHUB_OUTPUT"
 
       - name: build affected


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2786

## Summary

`Main CI` on `n3oltd/backend` has been **intermittently red** — failing on some merges and passing on the next with no actual build error. The failing job is `build`, which calls this reusable workflow (`n3o-dotnet-affected-build.yml`).

GitHub runs each `bash` step as `bash --noprofile --norc -e -o pipefail`, so a `grep` that matches nothing (exit 1) aborts the whole step. The `compute affected` step post-processes the diff with three such greps that can legitimately match nothing:

- `grep -E '\.csproj$'` over the changed-file list — a change set with no `.csproj`
- `grep -oE 'Include="…\.csproj"'` over `affected.proj` — an empty affected set
- `grep -v '^$'` over the merged project list — all-empty input

When the change-gate considers a push buildable but it produces no matching projects (e.g. a datafix touching only non-project files), one of these greps exits 1 and fails CI. Docs-only merges skip the `build` job entirely, which is why it looked intermittent. Confirmed on backend run [28379451742](https://github.com/n3oltd/backend/actions/runs/28379451742) (PR #51 merge), which errored immediately after `dotnet affected` wrote an empty `affected.proj`.

This guards each of those greps with `|| true` — a no-match means "nothing to add", not an error. The surrounding `find`/`jq`/`sort` logic already collapses empty input to `[]`, which is the documented "no affected projects" output, so behaviour is unchanged when there *are* matches.

## Test plan

- [x] Identified the failure: `build` job aborts right after an empty `affected.proj` write, under `bash -e -o pipefail`
- [ ] Merge, then push a commit that changes only non-project files (or re-run a datafix-style merge) and confirm `Main CI` `build` completes green with `projects=[]` instead of aborting
- [ ] Confirm a normal code change still resolves and builds its affected projects