### PR TITLE
Replace turbo build command with npm run build:n3o-elements in platforms-js workflow

### DIFF
--- a/.github/workflows/n3o-platforms-js-build-push.yml
+++ b/.github/workflows/n3o-platforms-js-build-push.yml
@@ -49,7 +49,7 @@ jobs:
       - name: npm install and build
         run: |
           npm ci --legacy-peer-deps
-          npx turbo build:lib --filter=@n3oltd/n3o-elements
+          npm run build:n3o-elements
         env:
           NODE_AUTH_TOKEN: ${{ env.GH_PAT }}
           VITE_SUBSCRIPTION_CODE: ${{ inputs.subscription-code }}


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2803

## Summary

Replaces `npx turbo build:lib --filter=@n3oltd/n3o-elements` with `npm run build:n3o-elements` in `.github/workflows/n3o-platforms-js-build-push.yml`.

Calling turbo directly with a filter flag is unnecessarily verbose and couples the CI step to turbo internals. Delegating to the package's own npm script is simpler and consistent with how other build steps are invoked.

## Test plan

- [x] Single-line change in `n3o-platforms-js-build-push.yml` — `npm run build:n3o-elements` replaces the turbo invocation.
- [ ] Trigger a platforms-js build for any subscription and confirm the build step completes successfully.