### PR TITLE
feat: base input on n3o-build-paths-changed

### DIFF
--- a/.github/actions/n3o-build-paths-changed/action.yml
+++ b/.github/actions/n3o-build-paths-changed/action.yml
@@ -1,6 +1,12 @@
 name: n3o build paths changed
 description: Coarse CI pre-gate — true when any build-relevant path changed (src, CPM props, global.json, nuget.config).
 
+inputs:
+  base:
+    description: Base ref/sha to diff against. Empty uses the event default (the push's before-sha).
+    required: false
+    default: ''
+
 outputs:
   changed:
     description: "'true' when a build-relevant path changed"
@@ -13,6 +19,7 @@ runs:
     - uses: dorny/paths-filter@v3
       id: filter
       with:
+        base: ${{ inputs.base }}
         filters: |
           build:
             - 'src/**'


### PR DESCRIPTION
Adds an optional `base` input (passed through to dorny/paths-filter) so callers can diff against an explicit base — e.g. the last successful CI commit — rather than only the push's before-sha. Backward compatible: empty `base` keeps the current event-default behaviour.

Enables the Main CI baseline fix in n3oltd/backend: a run superseded during a merge burst never builds, and today every gate diffs only that run's own increment, so the stranded changes are never picked up. Baselining on the last successful commit closes that gap.