### PR TITLE
Retry the ACR push once on transient failure

### DIFF
--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -166,8 +166,36 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # The ACR push intermittently fails on a transient registry error (e.g. BlobNotFound) after a
+      # good build. Try once (non-fatal), then retry; the buildx builder still holds the layers so
+      # the retry only re-pushes. The job fails only if both attempts fail.
       - name: build and push
+        id: build
         if: steps.check-existing.outputs.exists != 'true'
+        continue-on-error: true
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ${{ inputs.context }}
+          target: final
+          file: ${{ inputs.dockerfile }}
+          build-args: ${{ steps.build-args.outputs.args }}
+          secrets: |
+            github_token=${{ env.GH_PAT }}
+            sentry_auth_token=${{ env.SENTRY_AUTH_TOKEN }}
+            ${{ inputs.secrets }}
+          push: true
+          tags: |
+            ${{ steps.metadata.outputs.version-tag }}
+            ${{ steps.metadata.outputs.latest-tag }}
+            n3oltd.azurecr.io/${{ inputs.container-repository }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: build and push (retry)
+        if: steps.check-existing.outputs.exists != 'true' && steps.build.outcome == 'failure'
         uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
## Problem

`build-containers` intermittently fails at the **build and push** step on a transient registry error (an Azure `BlobNotFound` was observed). The build succeeds — the image is often present in ACR anyway — but the step returns non-zero. Because the matrix run fails if any service fails, and the nightly does `gh run watch --exit-status`, **one flaky service fails the whole run and skips the QA deploy** of every healthy service. The failing service is different each run (payments/lists one day, analytics the next), confirming it's transient, not a code break.

## Fix

Attempt the push once with `continue-on-error`, then retry once when the first attempt fails. The buildx builder created earlier in the job still holds the built layers, so the retry only re-pushes (no rebuild). The job fails only if **both** attempts fail, so a genuine build break still fails.

no-work-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)