### PR TITLE
Name build-push jobs by service so run job lists are readable

### DIFF
--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -64,6 +64,8 @@ env:
 
 jobs:
   pick:
+    # Name by the service so the run's job list identifies each build rather than repeating "pick".
+    name: ${{ inputs.container-repository }} (pick)
     uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
     with:
       # Default wait (self-hosted, free); a [ci fast] commit marker opts a single build into hosted.
@@ -71,7 +73,7 @@ jobs:
     secrets: inherit
 
   job1:
-    name: build-push
+    name: ${{ inputs.container-repository }}
     needs: pick
 
     # Default mode (wait) keeps these builds self-hosted only so they don't consume paid GitHub


### PR DESCRIPTION
## Problem

`n3o-docker-build-push` names its jobs with static literals (`pick`, `build-push`). In a matrix build (e.g. the nightly building 50+ services), the run's job list shows dozens of identical anonymous `pick` / `build-push` entries — you can't tell which service is which without opening each one.

## Fix

Interpolate `inputs.container-repository` into the job names:
- `build-push` → `${{ inputs.container-repository }}` (e.g. `svc-be-accounts`)
- `pick` → `${{ inputs.container-repository }} (pick)`

Every consumer of this reusable workflow (backend/sites/svc-*/devops/design — 10 callers) gets the clearer labels. Purely cosmetic; no protected branch requires a status check named `build-push` or `pick` (verified on backend/sites/frontend).

no-work-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)