### PR TITLE
Disable ffmpeg install in docker images

### DIFF
--- a/docker/n3o-dotnet
+++ b/docker/n3o-dotnet
@@ -64,7 +64,7 @@ ENV PATH="/dotnet-tools:$PATH"
 
 RUN apt-get --yes install zip unzip curl
 RUN apt-get --yes install libgdiplus
-RUN apt-get --yes install ffmpeg
+# RUN apt-get --yes install ffmpeg
 
 WORKDIR /app
 ENV ASPNETCORE_URLS http://*:80

--- a/docker/umbraco13
+++ b/docker/umbraco13
@@ -47,7 +47,7 @@ FROM base AS final
 
 RUN apt-get update
 RUN echo "yes" | apt install ttf-mscorefonts-installer --assume-yes
-RUN apt-get install --assume-yes curl wget zip unzip ghostscript git make gdebi fontconfig ffmpeg
+RUN apt-get install --assume-yes curl wget zip unzip ghostscript git make gdebi fontconfig
 
 ARG PROJECT
 


### PR DESCRIPTION
## What

Stop installing `ffmpeg` in our Docker base images, since it isn't currently used and it makes the images considerably larger.

- **`docker/n3o-dotnet`** — commented out `RUN apt-get --yes install ffmpeg`.
- **`docker/umbraco13`** — dropped `ffmpeg` from the `apt-get install` package list.

## Why

ffmpeg pulls in a large set of dependencies and inflates image size with no current consumer. Left as a commented-out line in n3o-dotnet so it's trivial to re-enable if a future feature needs it.

no-work-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)