### PR TITLE
npm-publish: rerun idempotency + per-package disk hygiene

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -51,15 +51,22 @@ runs:
             if [ "${{ inputs.version-suffix }}" != "" ];then
               npm version $version --preid=${{ inputs.version-suffix }}
             else
-              npm version $version; 
+              npm version $version;
             fi
             echo "//npm.pkg.github.com/:_authToken=${{ inputs.access-token }}" >> .npmrc;
             echo "@n3oltd:registry=https://npm.pkg.github.com" >> .npmrc;
-            if [ "${{ inputs.version-suffix }}" != "" ];then
-              npm publish --tag=${{ inputs.version-suffix }}  
+            name=$(npm pkg get name | tr -d '"')
+            effective=$(npm pkg get version | tr -d '"')
+            # An already-published version means a rerun after a partial publish: done, not an error.
+            if npm view "$name@$effective" version > /dev/null 2>&1; then
+              echo "skip (already published): $name@$effective"
+            elif [ "${{ inputs.version-suffix }}" != "" ];then
+              npm publish --tag=${{ inputs.version-suffix }}
             else
               npm publish --tag=latest
-            fi )
+            fi
+            # prepack installs a per-package node_modules; across hundreds of packages that fills the disk.
+            rm -rf node_modules )
         done
       working-directory: ${{github.workspace}}
       env: 


### PR DESCRIPTION
Two failure classes surfaced by today's estate-wide client publish (backend main-ci run 29001248891):

- **Reruns now resume instead of failing.** The version is `date + run_number`, which is attempt-invariant — after attempt 1 crashed mid-list, attempt 2 recomputed the same version, hit `E409 Cannot publish over existing version` on the first already-published package, and aborted the loop. The action now checks the registry for `name@version` and treats an already-published version as done, so a rerun completes the unpublished tail at the same version.
- **Disk hygiene for large publishes.** Each package's `prepack` runs `npm install && npm run build`, and nothing removed the per-package `node_modules` — across 456 selected directories that filled a hosted runner's disk (the attempt-1 crash: `No space left on device`). Each package's `node_modules` is now deleted after its publish.

`npm pkg get` replaces nothing existing — it's used for the registry check and avoids assuming `jq` on the runner image.

no-work-issue