### PR TITLE
Key guard-linked bot exemptions on the PR author, not the actor

### DIFF
--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -108,13 +108,17 @@ jobs:
         id: gate
         env:
           PR_MERGED: ${{ github.event.pull_request.merged }}
-          ACTOR: ${{ github.actor }}
+          # Exempt by PR author, not github.actor: a human editing a bot's PR retriggers
+          # the run with the human as actor, which must not defeat the exemption.
+          AUTHOR: ${{ github.event.pull_request.user.login }}
           # Escape hatch for a genuine untracked chore: a `no-work-issue` marker in the PR body.
           OPT_OUT: ${{ contains(github.event.pull_request.body, 'no-work-issue') }}
         run: |
           skip=false
           if [ "$PR_MERGED" = "true" ] || [ "$OPT_OUT" = "true" ]; then skip=true; fi
-          if [ "$ACTOR" = "dependabot[bot]" ] || [ "$ACTOR" = "n3o-babar[bot]" ]; then skip=true; fi
+          case "$AUTHOR" in
+            "dependabot[bot]"|"n3o-babar[bot]"|"n3o-github") skip=true;;
+          esac
           echo "skip=$skip" >> "$GITHUB_OUTPUT"
 
       - name: app token


### PR DESCRIPTION
## Linked work issue

`no-work-issue` — CI plumbing chore, no product change.

## Summary

The `guard-linked` exemption gate keyed on `github.actor` — whoever triggered the event — so it only skipped a bot's PR when the bot itself fired the event. A human ticking Renovate's rebase box or editing the PR re-ran the guard with the human as actor and failed the check (e.g. [backend run 29142889198](https://github.com/n3oltd/backend/actions/runs/29142889198), actor `nadrummond` on a Renovate PR). The same latent bug applied to dependabot PRs.

The intent is "PRs *authored* by bots are exempt", so the gate now checks `github.event.pull_request.user.login` instead, and adds `n3o-github` — the machine account our self-hosted Renovate authors PRs as — alongside `dependabot[bot]` and `n3o-babar[bot]`.

Companion change: n3oltd/backend now also stamps the `no-work-issue` marker into Renovate PR bodies via `prBodyNotes`, so Renovate PRs are covered belt-and-braces.

## Test plan

- [x] YAML parses
- [ ] Next Renovate PR event in a consuming repo skips the guard (gate logs `skip=true`)
- [ ] A human-authored PR without a reference still fails the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)