### PR TITLE
oauth-pnpm-static: authenticate pnpm install to GitHub Packages

### DIFF
--- a/docker/oauth-pnpm-static
+++ b/docker/oauth-pnpm-static
@@ -30,7 +30,15 @@ WORKDIR /repo
 COPY . .
 ARG PACKAGE
 ARG BUILD_SCRIPT
-RUN pnpm install --frozen-lockfile --filter "${PACKAGE}..."
+# The workspace lockfile can reference private @n3oltd GitHub Packages, which the
+# supply-chain check resolves for every entry. The committed .npmrc only maps the
+# scope to the registry; pnpm needs a literal auth token, written for this RUN only
+# (the build stage is not the pushed image, and the token is restored out again).
+RUN --mount=type=secret,id=github_token,required=true sh -eu -c '\
+  touch .npmrc && cp .npmrc .npmrc.bak && \
+  printf "\n//npm.pkg.github.com/:_authToken=%s\n" "$(cat /run/secrets/github_token)" >> .npmrc && \
+  pnpm install --frozen-lockfile --filter "${PACKAGE}..." && \
+  mv .npmrc.bak .npmrc'
 RUN pnpm --filter "${PACKAGE}" run "${BUILD_SCRIPT}"
 
 ########################

--- a/docker/oauth-pnpm-static
+++ b/docker/oauth-pnpm-static
@@ -30,10 +30,6 @@ WORKDIR /repo
 COPY . .
 ARG PACKAGE
 ARG BUILD_SCRIPT
-# The workspace lockfile can reference private @n3oltd GitHub Packages, which the
-# supply-chain check resolves for every entry. The committed .npmrc only maps the
-# scope to the registry; pnpm needs a literal auth token, written for this RUN only
-# (the build stage is not the pushed image, and the token is restored out again).
 RUN --mount=type=secret,id=github_token,required=true sh -eu -c '\
   touch .npmrc && cp .npmrc .npmrc.bak && \
   printf "\n//npm.pkg.github.com/:_authToken=%s\n" "$(cat /run/secrets/github_token)" >> .npmrc && \


### PR DESCRIPTION
## Problem

The `oauth-pnpm-static` Dockerfile does a bare `pnpm install` with no registry auth. That was fine while consumers' lockfiles were all-public, but a pnpm workspace lockfile that references **private `@n3oltd` GitHub Packages** fails: pnpm's supply-chain policy check resolves metadata for every lockfile entry on install, and the private entries `401`.

Concretely, `storybook.n3o.dev` (built via this image) has been failing to deploy since the frontend monorepo's lockfile first gained private `@n3oltd/*` SDK deps:
```
[ERR_PNPM_FETCH_401] GET https://npm.pkg.github.com/@n3oltd%2Fk2.subscriptions.sdk: Unauthorized - 401
```

## Fix

Consume the `github_token` BuildKit secret the reusable `n3o-docker-build-push.yml` **already passes to every build** (the same secret `n3o-vite`/`n3o-react` consume). The install RUN writes a literal `//npm.pkg.github.com/:_authToken=…` into `.npmrc` for that RUN only — the committed `.npmrc` merely maps the `@n3oltd` scope to the registry, and pnpm won't expand an env-var token in a committed `.npmrc` — then restores the file so the token lands in no layer. The build stage isn't the pushed image regardless.

## Verification

Built the `build` target against a clean frontend checkout with a real `github_token`: the install resolves the private `@n3oltd` SDKs (previously 401), both storybooks build, the site assembles, image exports. (The deploy also needs a `.dockerignore` fix in the frontend repo — PR'd separately; it surfaced once the install got past auth.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)