### PR TITLE
fix(dotnet-setup): skip setup-dotnet on self-hosted runners

### DIFF
--- a/.github/actions/n3o-dotnet-setup/action.yml
+++ b/.github/actions/n3o-dotnet-setup/action.yml
@@ -1,15 +1,29 @@
 name: n3o dotnet setup
-description: Central .NET SDK setup (setup-dotnet@v5 — skips the install when the SDK is baked into the runner).
+description: Central .NET SDK setup — uses the baked-in SDK on self-hosted runners, installs via setup-dotnet on GitHub-hosted.
 
 inputs:
   dotnet-version:
-    description: .NET SDK version to install
+    description: .NET SDK version to install on GitHub-hosted runners (self-hosted uses the baked-in SDK)
     required: false
     default: '10.x'
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-dotnet@v5
+    # Self-hosted bakes the SDK into a read-only /usr/share/dotnet; setup-dotnet would fail
+    # installing a newer patch there. Use the baked-in SDK.
+    - name: Use baked-in .NET SDK (self-hosted)
+      if: runner.environment != 'github-hosted'
+      shell: bash
+      run: |
+        if ! command -v dotnet >/dev/null 2>&1; then
+          echo "::error::dotnet not found on PATH; expected the self-hosted runner image to bake in the .NET SDK." >&2
+          exit 1
+        fi
+        echo "Using baked-in .NET SDK $(dotnet --version) at $(command -v dotnet)"
+
+    - name: Install .NET SDK (GitHub-hosted)
+      if: runner.environment == 'github-hosted'
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ inputs.dotnet-version }}

--- a/.github/actions/n3o-dotnet-setup/action.yml
+++ b/.github/actions/n3o-dotnet-setup/action.yml
@@ -10,8 +10,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Self-hosted bakes the SDK into a read-only /usr/share/dotnet; setup-dotnet would fail
-    # installing a newer patch there. Use the baked-in SDK.
     - name: Use baked-in .NET SDK (self-hosted)
       if: runner.environment != 'github-hosted'
       shell: bash


### PR DESCRIPTION
## What
`n3o-dotnet-setup` gated `setup-dotnet@v5` on nothing — it ran on every runner. Its description claimed it "skips the install when the SDK is baked into the runner," but setup-dotnet doesn't do that: with `dotnet-version: 10.x` it resolves the **newest patch published online** and installs it if not already present.

## The failure
On the self-hosted fleet the SDK is baked into a root-owned, read-only `/usr/share/dotnet`. When a newer 10.0.x patch ships (10.0.302 on 2026-07-14), setup-dotnet tries to install it there and dies:

```
cp: cannot create directory '/usr/share/dotnet/host/fxr/10.0.10/': Permission denied
dotnet_install: Error: .NET Core SDK with version = 10.0.302 failed to install with an error.
```

This intermittently killed legs across every workflow using this action — e.g. 4 legs of the last **Generate Clients** run (users, webhooks, whatsapp, zakat), which were then silently excluded from the regen PR.

## Fix
Gate on `runner.environment`:
- **self-hosted** → use the baked-in SDK (skip install; verify `dotnet` is present and fail loudly if not)
- **GitHub-hosted** (fast mode) → install via `setup-dotnet` as before

Fixes the action centrally, so all four consumers benefit: `n3o-dotnet-build`, `dotnet-build-pack-push`, `n3o-dotnet-affected-build`, and `n3o-dotnet-cli-setup`.

no-work-issue