### PR TITLE
chore(ci): centralise setup-node in an n3o-node-setup composite

### DIFF
--- a/.github/actions/n3o-node-setup/action.yml
+++ b/.github/actions/n3o-node-setup/action.yml
@@ -1,0 +1,38 @@
+name: n3o node setup
+description: The one place actions/setup-node is pinned.
+
+inputs:
+  node-version:
+    description: Node version. Omit when node-version-file is set.
+    required: false
+  node-version-file:
+    description: File to read the Node version from.
+    required: false
+  registry-url:
+    description: npm registry to write auth config for.
+    required: false
+  scope:
+    description: npm scope bound to the registry.
+    required: false
+  token:
+    description: Resolves the Node version manifest. npm registry auth reads NODE_AUTH_TOKEN from each npm step's env.
+    required: false
+  cache:
+    description: Package manager whose global cache to restore.
+    required: false
+  cache-dependency-path:
+    description: Lockfile path(s) the cache key derives from.
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version-file }}
+        registry-url: ${{ inputs.registry-url }}
+        scope: ${{ inputs.scope }}
+        token: ${{ inputs.token || (github.server_url == 'https://github.com' && github.token) || '' }}
+        cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}

--- a/.github/workflows/dotnet-build-pack-push.yml
+++ b/.github/workflows/dotnet-build-pack-push.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
-      - uses: actions/setup-node@v4
+      - uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         if: ${{ inputs.setup-node }}
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/n3o-dotnet-build-pack-push.yml
+++ b/.github/workflows/n3o-dotnet-build-pack-push.yml
@@ -102,7 +102,7 @@ jobs:
       # Installs a specific Node version, not the baked one.
       - name: setup-node
         if: inputs.npm-packages != ''
-        uses: actions/setup-node@v6
+        uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: '24'
 

--- a/.github/workflows/n3o-dotnet-generate-clients.yml
+++ b/.github/workflows/n3o-dotnet-generate-clients.yml
@@ -44,7 +44,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: setup-node
-        uses: actions/setup-node@v6
+        uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: '24'
 

--- a/.github/workflows/n3o-platforms-app-build-capgo.yml
+++ b/.github/workflows/n3o-platforms-app-build-capgo.yml
@@ -35,7 +35,7 @@ jobs:
           wait
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: 22
           cache: "npm"

--- a/.github/workflows/n3o-platforms-app-build-native.yml
+++ b/.github/workflows/n3o-platforms-app-build-native.yml
@@ -38,7 +38,7 @@ jobs:
           wait
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: '22.x'
           cache: "npm"
@@ -106,7 +106,7 @@ jobs:
           echo "CI_BUILD_NUMBER=${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: '22.x'
           cache: "npm"

--- a/.github/workflows/n3o-platforms-js-build-push.yml
+++ b/.github/workflows/n3o-platforms-js-build-push.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: setup-node
-        uses: actions/setup-node@v6
+        uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: '22.x'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/n3o-platforms-pages-build.yml
+++ b/.github/workflows/n3o-platforms-pages-build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: setup-node
-        uses: actions/setup-node@v6
+        uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/n3o-platforms-playground-build-deploy.yml
+++ b/.github/workflows/n3o-platforms-playground-build-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: setup-node
-        uses: actions/setup-node@v6
+        uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/n3o-react-build.yml
+++ b/.github/workflows/n3o-react-build.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: setup-node
-        uses: actions/setup-node@v6
+        uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: '14.x'
 

--- a/.github/workflows/n3o-vite-ci.yml
+++ b/.github/workflows/n3o-vite-ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: setup-node
-        uses: actions/setup-node@v6
+        uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: '22.x'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: n3oltd/actions/.github/actions/n3o-node-setup@main
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Linked work issue

no-work-issue — CI plumbing, nothing to link.

## Summary

`actions/setup-node` was pinned inline at 13 call sites across this repo, on two different majors (twelve on v6, `dotnet-build-pack-push` on v4), with backend and frontend carrying their own copies again. Nothing bumped any of them, because the estate's reusable steps are referenced `@main` and a floating ref carries no version for Dependabot to track.

This adds `n3o-node-setup`, a composite that is now the one place `actions/setup-node` is pinned, and points all 13 call sites at it. The pin stays at **v6** so the cutover is behaviour-identical; `dotnet-build-pack-push` moves v4 to v6 as a consequence. Adopting v7 is a separate PR stacked on this one.

The composite forwards the seven inputs the call sites actually use. `token` mirrors setup-node's own GHES guard rather than passing `github.token` unconditionally.

## Test plan

- [x] Every call-site input is declared by the composite — checked structurally, since a composite silently drops undeclared inputs
- [x] Empty-string forwarding is a no-op: `core.getInput` collapses absent and empty to `''`, so no call site changes behaviour
- [x] Nested post-job cache-save still fires (verified against a real run of an existing nested composite)
- [x] No workflow references outputs or a step id of the old setup-node step
- [x] All touched workflows parse
- [ ] Post-merge: confirm a consuming build still restores *and* saves its npm cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)