### PR TITLE
chore(ci): adopt actions/setup-node v7

### DIFF
--- a/.github/actions/n3o-node-setup/action.yml
+++ b/.github/actions/n3o-node-setup/action.yml
@@ -27,7 +27,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}

--- a/.github/workflows/n3o-platforms-js-build-push.yml
+++ b/.github/workflows/n3o-platforms-js-build-push.yml
@@ -85,6 +85,8 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${{ env.GH_PAT }}" >> .npmrc;
           echo "@n3oltd:registry=https://npm.pkg.github.com" >> .npmrc;
           npm publish;
+        env:
+          NODE_AUTH_TOKEN: ${{ env.GH_PAT }}
 
       - name: sentry release
         if: inputs.sentry-project != ''

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -33,6 +33,8 @@ jobs:
         run: |
           npm install --legacy-peer-deps
           npm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ env.GH_PAT }}
         working-directory: ${{ inputs.working-directory }}
           
       - name: npm publish
@@ -43,5 +45,6 @@ jobs:
           npm version $version --git-tag-version=false
           npm publish --tag latest
         env:
+          NODE_AUTH_TOKEN: ${{ env.GH_PAT }}
           NPM_CONFIG_LOGLEVEL: verbose
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,6 +47,8 @@ jobs:
         run: |
           npm install
           npm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
 
       - if: ${{ inputs.prepack }}
         run: |


### PR DESCRIPTION
## Linked work issue

no-work-issue — CI plumbing, nothing to link.

## Summary

Stacked on #156 — merge that first; this targets its branch so the diff stays reviewable.

Moves the `n3o-node-setup` pin from v6 to v7 and makes the registry-url call sites safe for it first.

v7 stops exporting the placeholder `NODE_AUTH_TOKEN` it used to inject when none was supplied. That matters more than it sounds: `registry-url` writes an `.npmrc` referencing `${NODE_AUTH_TOKEN}` and points `NPM_CONFIG_USERCONFIG` at it for the rest of the job, and npm aborts at config-parse time on an undefined variable rather than degrading to empty. So under v7 *every* package-manager step in a registry-url job needs the variable in env — whether or not that step authenticates.

Four steps were exposed and are fixed here:

| Workflow | Step |
| --- | --- |
| `npm-publish-github-packages.yml` | `npm install and build`, `npm publish` — the file had no `NODE_AUTH_TOKEN` at all |
| `npm-publish.yml` | `npm install`/`npm run build` — the publish step already had it |
| `n3o-platforms-js-build-push.yml` | `npm publish` — writes its own project `.npmrc`, but the temp userconfig is still active |

Backend has run v7 since n3oltd/backend#379, but neither of its call sites passes `registry-url`, so it never exercised this seam.

## Test plan

- [x] Audited every `npm`/`npx`/`pnpm`/`yarn` step in every registry-url job for `NODE_AUTH_TOKEN` in its effective env (step, job, workflow) — 8 steps, 0 failing
- [x] All touched workflows parse
- [ ] Post-merge: a real publish through `npm-publish-github-packages` succeeds
- [ ] Post-merge: a real publish through `npm-publish` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)