### PR TITLE
chore(ci): track GitHub Actions versions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 50
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Linked work issue

no-work-issue — CI plumbing, nothing to link.

## Summary

This repo is the estate's central action library and was the one repo whose own pins nothing updated — the inversion of what you want. It carries 14 distinct third-party actions across 30-odd references, including `actions/checkout` split across v6 and v4.

Adds Dependabot on the github-actions ecosystem, weekly, grouped into a single PR. Backend already runs this configuration; this matches it.

Note on coverage: version tracking applies to semver tags and SHAs, so the `n3oltd/actions/...@main` references in consuming repos resolve at run time and are not tracked. That is what makes the composite in #156 the useful place to pin.

## Test plan

- [x] Config parses
- [ ] Post-merge: first Dependabot run opens a grouped PR — confirm it includes `.github/actions/n3o-node-setup/action.yml`, not only `.github/workflows/`. GitHub's docs name `/.github/workflows` and the root `action.yml`; community reports say `.github/**`. If composites are not covered, add a `directories` glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)