### PR TITLE
chore(ci): scan composite actions for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 50


### PR DESCRIPTION
## Linked work issue

no-work-issue — CI plumbing, nothing to link.

## Summary

Follow-up to #158, which did not do what it was added to do.

The first Dependabot run landed as #159 and touched 30 files, every one of them under `.github/workflows/`. It did not touch `.github/actions/`. The `github-actions` ecosystem resolves a configured directory to that directory's `.github/workflows` and its root `action.yml` — composites nested under `.github/actions/*/action.yml` fall outside both.

That leaves 11 third-party pins across 9 composites untracked, `actions/checkout@v4` and `actions/cache@v4` among them, while the workflows beside them move to v7 and v6. It also means #156's whole premise — one place to pin `actions/setup-node` — currently has nothing keeping that place current.

Switching `directory` for `directories` and adding the composite path brings them in.

## Test plan

- [x] Config parses; `directory` and `directories` are mutually exclusive, so the old key is gone
- [ ] Post-merge: next Dependabot run touches `.github/actions/*/action.yml`
- [ ] Post-merge: confirm one grouped PR, not one per matched directory — globstar paths have been reported to duplicate, and `*` is used here rather than `**` for that reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)