### PR TITLE
chore(ci): drop the token input from node setup call sites

### DIFF
--- a/.github/workflows/n3o-platforms-js-build-push.yml
+++ b/.github/workflows/n3o-platforms-js-build-push.yml
@@ -36,7 +36,6 @@ jobs:
           node-version: '22.x'
           registry-url: 'https://npm.pkg.github.com'
           cache: 'npm'
-          token: ${{ env.GH_PAT }}
           
       - name: Fetch config files
         run: |

--- a/.github/workflows/n3o-platforms-pages-build.yml
+++ b/.github/workflows/n3o-platforms-pages-build.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'
-          token: ${{ env.GH_PAT }}
 
       - name: npm install and build
         run: |

--- a/.github/workflows/n3o-platforms-playground-build-deploy.yml
+++ b/.github/workflows/n3o-platforms-playground-build-deploy.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'
-          token: ${{ env.GH_PAT }}      
 
       - name: npm install and build
         run: |

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           node-version: '22.x'
           registry-url: 'https://npm.pkg.github.com'
-          token: ${{ env.GH_PAT }}
 
       - name: npm install and build
         run: |


### PR DESCRIPTION
## Linked work issue

no-work-issue — CI plumbing, nothing to link.

## Summary

Four call sites passed a PAT to the node setup step's `token` input. That input resolves the Node version manifest and already defaults to the job token, so the PAT worked — but its presence read as though the step carried npm registry auth.

It does not. Registry auth comes from `NODE_AUTH_TOKEN` in each npm step's env, which is a separate mechanism entirely. That conflation is what allowed a real failure to hide: the sites looked authenticated, so the steps that genuinely lacked `NODE_AUTH_TOKEN` were easy to read past when v7 stopped supplying a placeholder.

Removing the input leaves the composite to fall back to the job token, matching the nine call sites that never passed one.

## Test plan

- [x] All 13 composite call sites parse; none passes `token`, none left with an empty `with:` block
- [x] The remaining `token:` in the repo belongs to a checkout step using a GitHub App token and is untouched
- [x] `access-token:` inputs on other composites are a different input and are untouched
- [ ] Post-merge: a platforms build and a GitHub Packages publish both still resolve Node and authenticate to the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)