### PR TITLE
Reclaim fleet runner disk before build when low

### DIFF
--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -168,6 +168,23 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # Fleet runners are persistent, so BuildKit cache and images accrue across builds. Prune only
+      # when free space is low: routine builds keep a warm cache; a saturated runner self-heals.
+      - name: reclaim disk if low
+        if: steps.check-existing.outputs.exists != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          avail_gb=$(df -BG --output=avail / 2>/dev/null | tail -1 | tr -dc '0-9' || echo 0)
+          echo "Free space on /: ${avail_gb}G"
+          if [ "${avail_gb:-0}" -lt 25 ]; then
+            echo "::notice title=Reclaiming disk::Low disk (${avail_gb}G) — pruning BuildKit cache and unused images"
+            docker buildx prune --all --force || true
+            docker image prune --all --force || true
+            docker container prune --force || true
+            df -BG / | tail -1
+          fi
+
       # The ACR push intermittently fails on a transient registry error (e.g. BlobNotFound) after a
       # good build. Try once (non-fatal), then retry; the buildx builder still holds the layers so
       # the retry only re-pushes. The job fails only if both attempts fail.


### PR DESCRIPTION
## Problem

Nightly service builds run in `wait` mode on the **persistent self-hosted fleet** (`n3o-github-runner`). Those runners are never wiped between jobs, so the BuildKit cache (`docker/setup-buildx-action`'s builder volume) and image layers accumulate across runs until a runner reaches 100% disk. When that happens the **runner process itself dies mid-build** — it can't write its own diagnostic log:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/.../_diag/Worker_...log'
```

Seen in the [main Nightlies run 29898059402](https://github.com/n3oltd/backend/actions/runs/29898059402), where `svc-be-payments` failed with a disk error (not a build error) while every other service built fine — the signature of a saturated runner rather than a code fault.

Nothing in the build path (`n3o-docker-build-push.yml` → `n3o-pick-runner.yml`) reclaims disk today.

## Fix

Add a `reclaim disk if low` step before `build and push`. It checks free space and only prunes when below 25G, so:

- the common case keeps a **warm cache** (the whole reason for self-hosted), and
- a near-full runner **self-heals at the start of the next job** — no manual host cleanup needed.

Pruning is `|| true` so a cleanup hiccup can never fail a build, and it avoids `--volumes` so it won't disturb the builder just created by `setup-buildx-action`.

This lives in the shared reusable workflow, so it applies to **every service build**, not just payments.

no-work-issue