### PR TITLE
fix(postgres): apply all tenant secrets, not just one

### DIFF
--- a/.github/workflows/n3o-aks-deploy-postgres.yml
+++ b/.github/workflows/n3o-aks-deploy-postgres.yml
@@ -57,9 +57,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
         run: |
-          echo ${{ secrets[steps.get-secret-name.outputs.secretName] }}
-          secretsYml=$(n3o utilities decrypt --path ./postgresSecrets.yaml --key ${{ secrets[steps.get-secret-name.outputs.secretName] }})
-          echo $secretsYml > ./postgresSecretsDecrypted.yaml
+          n3o utilities decrypt --path ./postgresSecrets.yaml --key ${{ secrets[steps.get-secret-name.outputs.secretName] }} > ./postgresSecretsDecrypted.yaml
               
       - name: Apply Secrets YAML to the cluster
         uses: n3oltd/actions/.github/actions/n3o-kubectl-apply-file@main


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

All tenant `postgres-<suffix>-0` pods except `prod` were stuck in `CreateContainerConfigError` with `couldn't find key agent-ro-password in Secret default/postgres-secrets-<suffix>`.

Root cause: the *Decrypt the secrets yml* step in `n3o-aks-deploy-postgres.yml` captured the decrypted **multi-document** secrets YAML (one `Secret` per tenant, `---`-separated) into a shell variable and wrote it back with an **unquoted** `echo $secretsYml`. Word-splitting collapsed every newline and `---` separator into single spaces, mangling the file into one blob, so `kubectl apply -f` applied only a single Secret (`postgres-secrets-prod`) and reported success — the other 33 `postgres-secrets-<suffix>` were silently never applied. (The StatefulSet apply step was unaffected because it applies per-file via `find ... -exec kubectl apply -f {}`.)

This was latent for a long time — tenant secrets had been frozen at their original state — and only surfaced when the postgres StatefulSet template began requiring the `agent-ro-password` / `agent-rw-password` keys. Every tenant except `prod` lacked those keys in its stale secret and failed to start; `prod` worked only because it happens to be the single Secret the broken step applied.

This change redirects the decrypt output straight to the file, preserving the multi-document YAML so all tenant secrets are applied on every deploy. It also removes the preceding `echo` that printed the decryption key into the workflow log.

## Test plan

- [ ] Re-run the EU1 postgres deploy (`EU1 / Postgress / All`, or re-run `n3o deploy postgres server`) after merge.
- [ ] Confirm the *Apply Secrets YAML* step now reports `secret/postgres-secrets-<suffix> configured` for all tenants, not just `postgres-secrets-prod`.
- [ ] Confirm each `postgres-secrets-<suffix>` now contains `agent-ro-password` and `agent-rw-password`.
- [ ] Confirm all `postgres-<suffix>-0` pods reach `2/2 Running` (they self-heal from `CreateContainerConfigError` once the secret keys exist — no manual restart needed).
- [ ] Confirm the decryption key no longer appears in the workflow logs.
