### PR TITLE
fix(postgres): normalize CR line endings so all tenant secrets apply

### DIFF
--- a/.github/workflows/n3o-aks-deploy-postgres.yml
+++ b/.github/workflows/n3o-aks-deploy-postgres.yml
@@ -57,7 +57,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.N3O_CLI_AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.N3O_CLI_AZURE_CLIENT_SECRET }}
         run: |
-          n3o utilities decrypt --path ./postgresSecrets.yaml --key ${{ secrets[steps.get-secret-name.outputs.secretName] }} > ./postgresSecretsDecrypted.yaml
+          n3o utilities decrypt --path ./postgresSecrets.yaml --key ${{ secrets[steps.get-secret-name.outputs.secretName] }} | tr '\r' '\n' > ./postgresSecretsDecrypted.yaml
               
       - name: Apply Secrets YAML to the cluster
         uses: n3oltd/actions/.github/actions/n3o-kubectl-apply-file@main


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Follow-up to #164, which did **not** actually fix the postgres outage (my earlier root cause was wrong — apologies).

All ~34 tenant Secrets are decrypted into a single file separated by `---`. The generating template `PostgresSecretsYaml.handlebars` is stored with **bare CR (`\r`) line endings** and no `\n` at all, and the CLI's `yaml.Replace("\r\n", "\n")` is a no-op against bare CR, so the committed encrypted artifact keeps CR-only line endings.

kubectl's YAML parser does not treat a bare `\r` as a line break, so the `---` document separators are never recognized — the whole file is parsed as a **single** document and only one Secret (`postgres-secrets-prod`) is applied. The other 33 tenant secrets are silently skipped, which is why every postgres pod except `prod` hit `CreateContainerConfigError` once the StatefulSet template began requiring `agent-ro-password` / `agent-rw-password`. StatefulSets were unaffected because they are applied one-document-per-file.

This pipes the decrypted output through `tr '\r' '\n'` before writing, so the `---` separators land on real line boundaries and all tenant secrets apply. Safe because every secret value is single-line base64 — the only `\r` in the stream are structural line breaks. Fixing it in the workflow (rather than the CLI generator) also repairs the already-committed artifact and takes effect immediately on merge, with no CLI release cycle.

Follow-up (not required for recovery, needs a CLI release): fix the template's line endings + add a `.gitattributes` `eol=lf` rule, and make the generator normalize bare `\r` as well as `\r\n`.

## Test plan

- [x] `kubectl apply --dry-run=client` on a 2-document file: CR-only line endings → 1 object applied; `\n` line endings → both applied (confirms the mechanism).
- [ ] Merge, then re-run the EU1 postgres deploy (`EU1 / Postgress / All`).
- [ ] Apply-secrets step reports `secret/postgres-secrets-<suffix> configured` for **all 34** tenants, not just `prod`.
- [ ] All `postgres-<suffix>-0` pods reach `2/2 Running` (self-heal from `CreateContainerConfigError`).
