### PR TITLE
Set the WAL settings on the postgres command line

### DIFF
--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -27,17 +27,6 @@ sed -i "/log_lock_waits/d" /var/lib/postgresql/data/postgres/postgresql.conf
   echo "ssl_cert_file = '/var/lib/postgresql/server.crt'"
   echo "ssl_key_file = '/var/lib/postgresql/server.key'"
   
-  echo "logging_collector = on"
-  echo "log_directory = 'log'"
-  echo "log_filename = 'postgresql-%Y-%m-%d.log'"
-  echo "log_rotation_age = 1d"
-  echo "log_rotation_size = 0"
-  echo "log_line_prefix = '%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h '"
-  echo "log_min_duration_statement = 0"
-  echo "log_checkpoints = on"
-  echo "log_connections = on"
-  echo "log_disconnections = on"
-  echo "log_lock_waits = on"
 } >> /var/lib/postgresql/data/postgres/postgresql.conf
 
 sed -i "/ssl/d" /var/lib/postgresql/data/postgres/postgresql.conf
@@ -80,6 +69,17 @@ exec docker-entrypoint.sh postgres \
           -c archive_command="pgbackrest --stanza=n3o archive-push %p" \
           -c wal_level=replica \
           -c max_wal_senders=3 \
+          -c logging_collector=on \
+          -c log_directory="log" \
+          -c log_filename="postgresql-%Y-%m-%d.log" \
+          -c log_rotation_age=1d \
+          -c log_rotation_size=0 \
+          -c log_line_prefix="%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h " \
+          -c log_min_duration_statement=0 \
+          -c log_checkpoints=on \
+          -c log_connections=on \
+          -c log_disconnections=on \
+          -c log_lock_waits=on \
           -c shared_buffers="${POSTGRES_SHARED_BUFFERS}" \
           -c max_connections="${POSTGRES_MAX_CONNECTIONS}" \
           -c work_mem="${POSTGRES_WORK_MEM}" \

--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -23,10 +23,6 @@ sed -i "/log_disconnections/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/log_lock_waits/d" /var/lib/postgresql/data/postgres/postgresql.conf
 
 {
-  echo "archive_mode = on"
-  echo "archive_command = 'pgbackrest --stanza=n3o archive-push %p'"
-  echo "wal_level = replica"
-  echo "max_wal_senders = 3"
   echo "ssl = on"
   echo "ssl_cert_file = '/var/lib/postgresql/server.crt'"
   echo "ssl_key_file = '/var/lib/postgresql/server.key'"
@@ -80,6 +76,10 @@ mkdir /etc/pgbackrest/backup-repo
 
 # Unit of tcp_keepalives_idle is seconds and idle_session_timeout is milliseconds
 exec docker-entrypoint.sh postgres \
+          -c archive_mode=on \
+          -c archive_command="pgbackrest --stanza=n3o archive-push %p" \
+          -c wal_level=replica \
+          -c max_wal_senders=3 \
           -c shared_buffers="${POSTGRES_SHARED_BUFFERS}" \
           -c max_connections="${POSTGRES_MAX_CONNECTIONS}" \
           -c work_mem="${POSTGRES_WORK_MEM}" \


### PR DESCRIPTION
no-work-issue

## Summary

Tenant 71's nightly backup had failed every run since the tenant was created, and the cause was that its PostgreSQL had `archive_mode = off` — no WAL archiving, so pgBackRest could not work at all. It had no valid backup of any kind: the repository in its blob container held backups belonging to a different database instance (`system-id` mismatch), and its own weekly full backup had not yet come round.

The entrypoint writes `archive_mode`, `archive_command`, `wal_level` and `max_wal_senders` into `postgresql.conf` before starting the server. That works when this script is what puts the data directory together, and only then — a data directory arriving by any other route (restored, copied, seeded from elsewhere) brings its own `postgresql.conf`, the settings are simply absent, and the server starts happily with archiving off.

Nothing catches it. The server is healthy, the tenant serves traffic, and the only signal is a CronJob failing in the background — which is how this ran for as long as it did.

The four settings now go on the postgres command line alongside `shared_buffers` and the other tuning parameters. Command-line settings are applied by the postmaster regardless of what the data directory contains, so a tenant cannot start with archiving off however its data directory came to exist. They are removed from the file-append block so there is one source for them rather than two.

I could not establish how tenant 71's data directory came to lack the settings, and this change deliberately does not depend on knowing — it removes the class of failure rather than the instance.

## Separately, not changed here

`ssl = on`, `ssl_cert_file` and `ssl_key_file` are appended to `postgresql.conf`, and then three `sed -i "/ssl/d"` lines immediately below delete every line matching `ssl` — including the three just written. Every tenant runs with `ssl = off` as a result, verified on two. Fixing it enables TLS on 34 live databases, which wants its own change and its own verification rather than riding along here.

## Test plan

- [x] `bash -n` passes on the modified entrypoint
- [x] Tenant 71 repaired live: stanza upgraded, WAL settings applied, server restarted, `pgbackrest check` passes, first full backup taken (`20260801-000642F`)
- [x] All 34 tenants audited for `archive_mode` — 71 was the only one affected, the rest are `on`
- [ ] Next tenant built from this image comes up with `archive_mode = on` sourced from the command line
