### PR TITLE
Say why every tenant runs with ssl off

### DIFF
--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -29,6 +29,9 @@ sed -i "/log_lock_waits/d" /var/lib/postgresql/data/postgres/postgresql.conf
   
 } >> /var/lib/postgresql/data/postgres/postgresql.conf
 
+# These three delete the ssl settings written immediately above, because /ssl/d matches them
+# too. Every tenant therefore runs with ssl off. Removing them turns TLS on across every live
+# database at once, so it needs its own change rather than a quiet fix here.
 sed -i "/ssl/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/ssl_cert_file/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/ssl_key_file/d" /var/lib/postgresql/data/postgres/postgresql.conf


### PR DESCRIPTION
no-work-issue

## Summary

The entrypoint writes `ssl = on`, `ssl_cert_file` and `ssl_key_file` into `postgresql.conf`, and three `sed -i "/ssl/d"` lines immediately below delete them again — `/ssl/d` matches the lines just written. Every tenant runs with `ssl = off` as a result, verified on live databases.

Reading the file top to bottom, it looks as though TLS is enabled. This adds a comment at the `sed` lines saying it is not, and why the obvious fix is not applied here: deleting those three lines turns TLS on across every live database at once, which is a behaviour change wanting its own verification rather than a quiet correction inside an unrelated commit.

No behaviour change.

## Test plan

- [x] `bash -n` passes
- [x] `ssl = off` confirmed on live tenants
