### PR TITLE
Move tenant Postgres authentication to SCRAM and bring pgbouncer current

### DIFF
--- a/docker/assets/pgbouncer-entrypoint.sh
+++ b/docker/assets/pgbouncer-entrypoint.sh
@@ -7,12 +7,29 @@ PG_CONFIG_FILE="${PG_CONFIG_DIR}/pgbouncer.ini"
 AUTH_FILE="${PG_CONFIG_DIR}/userlist.txt"
 
 mkdir -p "$PG_CONFIG_DIR"
-touch "$AUTH_FILE"
 
-if ! grep -q "^\"${POSTGRES_USER}\"" "$AUTH_FILE"; then
-    HASH="md5$(echo -n "${POSTGRES_PASSWORD}${POSTGRES_USER}" | md5sum | awk '{print $1}')"
-  echo "\"${POSTGRES_USER}\" \"$HASH\"" >> "$AUTH_FILE"
+# Application logins resolve through auth_query against pg_shadow, which returns the role's SCRAM
+# verifier. The auth file exists only so the admin and stats console has a credential to check,
+# and it holds that verifier rather than the password — a verifier cannot be replayed to obtain a
+# login, so nothing password-equivalent is written to disk.
+#
+# Reading it needs the database up. pgbouncer and postgres share the pod's network namespace and
+# pg_hba grants trust on 127.0.0.1, so no credential is needed to fetch it.
+until pg_isready -h "${HOST}" -p "${PORT}" -U "${POSTGRES_USER}" >/dev/null 2>&1; do
+  echo "Waiting for Postgres before reading the SCRAM verifier..."
+  sleep 2
+done
+
+VERIFIER=$(psql -h "${HOST}" -p "${PORT}" -U "${POSTGRES_USER}" -d postgres -tAc \
+  "SELECT rolpassword FROM pg_authid WHERE rolname = current_user")
+
+if [[ "$VERIFIER" != SCRAM-SHA-256\$* ]]; then
+  echo "No SCRAM verifier for ${POSTGRES_USER} (got '${VERIFIER:0:16}'); refusing to start." >&2
+  exit 1
 fi
+
+umask 077
+printf '"%s" "%s"\n' "${POSTGRES_USER}" "${VERIFIER}" > "$AUTH_FILE"
 
 cat > "$PG_CONFIG_FILE" <<EOF
 [databases]
@@ -21,19 +38,18 @@ cat > "$PG_CONFIG_FILE" <<EOF
 [pgbouncer]
 listen_addr = ${LISTEN_ADDR}
 listen_port = ${LISTEN_PORT}
-auth_type = md5
+auth_type = scram-sha-256
 auth_file = ${AUTH_FILE}
+auth_dbname = postgres
 admin_users = ${POSTGRES_USER}
 stats_users = ${POSTGRES_USER}
-listen_port = 6432                             
-auth_type = md5
-auth_file = /etc/pgbouncer/userlist.txt
 logfile = /dev/stdout
 pidfile = /var/run/pgbouncer/pgbouncer.pid
 pool_mode = transaction
 max_client_conn = ${MAX_CONNECTIONS}
 max_db_connections = ${MAX_CONNECTIONS}
 max_user_connections = ${MAX_CONNECTIONS}
+max_prepared_statements = 100
 server_reset_query = DISCARD ALL
 server_idle_timeout = ${POSTGRES_IDLE_SESSION_TIMEOUT}
 server_fast_close = 1

--- a/docker/assets/pgbouncer-entrypoint.sh
+++ b/docker/assets/pgbouncer-entrypoint.sh
@@ -8,13 +8,8 @@ AUTH_FILE="${PG_CONFIG_DIR}/userlist.txt"
 
 mkdir -p "$PG_CONFIG_DIR"
 
-# Application logins resolve through auth_query against pg_shadow, which returns the role's SCRAM
-# verifier. The auth file exists only so the admin and stats console has a credential to check,
-# and it holds that verifier rather than the password — a verifier cannot be replayed to obtain a
-# login, so nothing password-equivalent is written to disk.
-#
-# Reading it needs the database up. pgbouncer and postgres share the pod's network namespace and
-# pg_hba grants trust on 127.0.0.1, so no credential is needed to fetch it.
+# No credential is needed here: postgres shares the pod's network namespace and pg_hba grants
+# trust on 127.0.0.1.
 until pg_isready -h "${HOST}" -p "${PORT}" -U "${POSTGRES_USER}" >/dev/null 2>&1; do
   echo "Waiting for Postgres before reading the SCRAM verifier..."
   sleep 2
@@ -28,6 +23,8 @@ if [[ "$VERIFIER" != SCRAM-SHA-256\$* ]]; then
   exit 1
 fi
 
+# Only the admin console reads this; application logins go through auth_query. A verifier cannot
+# be replayed into a login, so nothing password-equivalent lands on disk.
 umask 077
 printf '"%s" "%s"\n' "${POSTGRES_USER}" "${VERIFIER}" > "$AUTH_FILE"
 

--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -95,9 +95,8 @@ until pg_isready -U "${POSTGRES_USER}" -d :"${POSTGRES_USER}"; do
   sleep 2
 done
 
-# Seed the read-only / read-write agent roles (idempotent). Re-running ALTER ROLE on every start
-# is what migrates an existing md5 hash to a SCRAM verifier, so pgbouncer's auth_query returns a
-# verifier it can check under auth_type=scram-sha-256.
+# Seed the read-only / read-write agent roles (idempotent). auth_query hands pgbouncer whatever
+# pg_authid holds, so this encryption and pgbouncer's auth_type have to agree.
 if [ -n "${AGENT_RO_PASSWORD}" ] && [ -n "${AGENT_RW_PASSWORD}" ]; then
   psql -U "${POSTGRES_USER}" -d postgres -v ro_pw="${AGENT_RO_PASSWORD}" -v rw_pw="${AGENT_RW_PASSWORD}" <<'EOSQL'
 SET password_encryption = 'scram-sha-256';

--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -87,17 +87,20 @@ exec docker-entrypoint.sh postgres \
           -c max_connections="${POSTGRES_MAX_CONNECTIONS}" \
           -c work_mem="${POSTGRES_WORK_MEM}" \
           -c tcp_keepalives_idle="${POSTGRES_TCP_KEEPALIVES_IDLE}" \
-          -c idle_session_timeout="${POSTGRES_IDLE_SESSION_TIMEOUT}" &
+          -c idle_session_timeout="${POSTGRES_IDLE_SESSION_TIMEOUT}" \
+          -c password_encryption=scram-sha-256 &
 
 until pg_isready -U "${POSTGRES_USER}" -d :"${POSTGRES_USER}"; do
   echo "Waiting for Postgres to be ready..."
   sleep 2
 done
 
-# Seed the read-only / read-write agent roles (idempotent; md5 so pgbouncer can proxy them)
+# Seed the read-only / read-write agent roles (idempotent). Re-running ALTER ROLE on every start
+# is what migrates an existing md5 hash to a SCRAM verifier, so pgbouncer's auth_query returns a
+# verifier it can check under auth_type=scram-sha-256.
 if [ -n "${AGENT_RO_PASSWORD}" ] && [ -n "${AGENT_RW_PASSWORD}" ]; then
   psql -U "${POSTGRES_USER}" -d postgres -v ro_pw="${AGENT_RO_PASSWORD}" -v rw_pw="${AGENT_RW_PASSWORD}" <<'EOSQL'
-SET password_encryption = 'md5';
+SET password_encryption = 'scram-sha-256';
 DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'n3o_agent_ro') THEN CREATE ROLE n3o_agent_ro LOGIN; END IF; END $$;
 DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'n3o_agent_rw') THEN CREATE ROLE n3o_agent_rw LOGIN; END IF; END $$;
 ALTER ROLE n3o_agent_ro PASSWORD :'ro_pw';

--- a/docker/pgbouncer
+++ b/docker/pgbouncer
@@ -8,9 +8,7 @@ FROM debian:trixie-slim AS base
 ########################
 FROM base AS final
 
-# PGDG rather than Debian's own: trixie ships pgbouncer 1.24.1, PGDG ships 1.25.2. 1.21 is the
-# floor for max_prepared_statements, which is what allows prepared statements at all under
-# transaction pooling.
+# PGDG rather than Debian's own, whose pgbouncer predates max_prepared_statements.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends wget ca-certificates \
  && echo "deb http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list \

--- a/docker/pgbouncer
+++ b/docker/pgbouncer
@@ -1,14 +1,23 @@
 ########################
 ### base
 ########################
-FROM debian:bookworm-slim AS base
+FROM debian:trixie-slim AS base
 
 ########################
 ### final
 ########################
 FROM base AS final
 
-RUN apt-get update && apt-get install -y wget pgbouncer postgresql-client bash procps && rm -rf /var/lib/apt/lists/*
+# PGDG rather than Debian's own: trixie ships pgbouncer 1.24.1, PGDG ships 1.25.2. 1.21 is the
+# floor for max_prepared_statements, which is what allows prepared statements at all under
+# transaction pooling.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends wget ca-certificates \
+ && echo "deb http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+ && wget -qO /etc/apt/trusted.gpg.d/pgdg.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends pgbouncer postgresql-client bash procps \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /etc/pgbouncer
 
@@ -18,9 +27,7 @@ RUN chmod +x /usr/local/bin/pgbouncer-entrypoint.sh
 RUN touch /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt
 RUN mkdir -p /var/log/pgbouncer
 
-RUN mkdir -p /var/run/pgbouncer && chown -R postgres:postgres /var/run/pgbouncer
-
-ENV AUTH_TYPE=md5
+RUN mkdir -p /var/run/pgbouncer && chown -R postgres:postgres /var/run/pgbouncer /etc/pgbouncer
 
 USER postgres
 


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

The agent roles that the SQL MCP and agent tooling log in as were pinned to md5 password hashes, because pgbouncer's `auth_query` had to return something `auth_type=md5` could verify. PostgreSQL 18 deprecates md5 passwords and warns on every `CREATE ROLE`/`ALTER ROLE` that sets one, so the pinning stops being a stylistic problem and becomes noise on every pod start. This moves both sides to `scram-sha-256` together.

The postgres entrypoint now sets `password_encryption` on the command line alongside the other server settings, and seeds the agent roles under it. Because the seeding runs `ALTER ROLE ... PASSWORD` on every start, an existing md5 hash is rewritten as a SCRAM verifier the first time a tenant picks up this image — there is no separate migration step.

pgbouncer reads its console credential out of `pg_authid` instead of deriving an md5 hash from `POSTGRES_PASSWORD`. The auth file therefore holds a SCRAM verifier, which cannot be replayed to obtain a login, rather than an md5 hash, which under md5 auth is exactly password-equivalent. Application logins never touch that file at all — they resolve through `auth_query` against `pg_shadow`.

Worth recording because it is what makes the above safe: nothing needing a credential crosses the pgbouncer-to-postgres hop. The two containers share the pod's network namespace and `pg_hba.conf` grants `trust` on `127.0.0.1`, so pgbouncer's backend connections and its verifier lookup are both unauthenticated over loopback. This also means SCRAM pass-through, and its constraints, do not apply here.

pgbouncer moves from bookworm's 1.18.0 (2023) to PGDG's 1.25.2. Beyond several years of fixes, 1.21 is the floor for `max_prepared_statements`; below it, prepared statements cannot be used at all under transaction pooling, which rules out Npgsql's `Max Auto Prepare` for a warehouse workload that runs the same query shapes repeatedly. It is enabled here at 100.

The generated ini also had `listen_port`, `auth_type` and `auth_file` written twice with identical values. Those duplicates are gone.

**This is deliberately not the TLS fix.** The `sed -i "/ssl/d"` that deletes the ssl settings the entrypoint just wrote is still there. Removing it would start every tenant with the certificate in `CredentialsStore.Ssl` — and that certificate expired on **2026-02-08**, six months ago, which I confirmed against `/var/lib/postgresql/server.crt` on `postgres-prod-0`. TLS needs a certificate source decided first and is tracked separately in #3273.

## Test plan

- [x] Built both images locally and ran them sharing a network namespace, as they do in a pod.
- [x] After the entrypoint seeds them, `pg_authid` shows `SCRAM-SHA-256` for `postgres-<suffix>`, `n3o_agent_ro` and `n3o_agent_rw` — previously md5 for the two agent roles.
- [x] `n3o_agent_ro` authenticates through pgbouncer on 6432 with the correct password and reaches the backend.
- [x] A wrong password is rejected with `FATAL: SASL authentication failed` — confirming the SCRAM path, not a silent md5 fallback.
- [x] The admin console (`SHOW POOLS`, `SHOW STATS`) authenticates against the verifier in the auth file.
- [x] `userlist.txt` contains no occurrence of the password, and is mode 0640.
- [x] `PREPARE`/`EXECUTE` succeeds through the transaction pool — not possible on 1.18.0.
- [x] pgbouncer reports 1.25.2 and listens on `0.0.0.0:6432`.
- [ ] Rollout is per-tenant and needs scheduling; both images must be rebuilt before any tenant is redeployed, since a pod that picks up one and not the other has mismatched auth on either side of loopback.
