### PR TITLE
Copy the entrypoints into the images instead of fetching them at build time

### DIFF
--- a/.github/workflows/n3o-docker-build-push-pgbouncer.yml
+++ b/.github/workflows/n3o-docker-build-push-pgbouncer.yml
@@ -24,11 +24,13 @@ jobs:
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
-      - name: fetch dockerfile
+      - name: fetch dockerfile and entrypoint
         shell: bash
         run: |
           curl -fsSL -o pgbouncer \
             https://raw.githubusercontent.com/n3oltd/actions/main/docker/pgbouncer
+          curl -fsSL -o pgbouncer-entrypoint.sh \
+            https://raw.githubusercontent.com/n3oltd/actions/main/docker/assets/pgbouncer-entrypoint.sh
 
       - id: meta-pgbouncer
         name: prepare pgbouncer

--- a/.github/workflows/n3o-docker-build-push-postgres.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres.yml
@@ -24,11 +24,13 @@ jobs:
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
-      - name: fetch dockerfile
+      - name: fetch dockerfile and entrypoint
         shell: bash
         run: |
           curl -fsSL -o postgres \
             https://raw.githubusercontent.com/n3oltd/actions/main/docker/postgres
+          curl -fsSL -o postgres-entrypoint.sh \
+            https://raw.githubusercontent.com/n3oltd/actions/main/docker/assets/postgres-entrypoint.sh
 
       - id: meta-postgres
         name: prepare postgres

--- a/docker/pgbouncer
+++ b/docker/pgbouncer
@@ -8,7 +8,7 @@ FROM debian:trixie-slim AS base
 ########################
 FROM base AS final
 
-# PGDG rather than Debian's own, whose pgbouncer predates max_prepared_statements.
+# PGDG rather than Debian's own, which lags upstream pgbouncer releases.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends wget ca-certificates \
  && echo "deb http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
@@ -19,16 +19,16 @@ RUN apt-get update \
 
 WORKDIR /etc/pgbouncer
 
-RUN wget -P /usr/local/bin https://raw.githubusercontent.com/n3oltd/actions/main/docker/assets/pgbouncer-entrypoint.sh
-RUN chmod +x /usr/local/bin/pgbouncer-entrypoint.sh
+# COPY, not a RUN that fetches: a RUN's cache key is its command string, which never changes, so
+# a warm builder reuses the layer and ships whatever the entrypoint was when it was first built.
+COPY --chmod=0755 pgbouncer-entrypoint.sh /usr/local/bin/pgbouncer-entrypoint.sh
 
-RUN touch /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt
-RUN mkdir -p /var/log/pgbouncer
-
-RUN mkdir -p /var/run/pgbouncer && chown -R postgres:postgres /var/run/pgbouncer /etc/pgbouncer
+RUN touch /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt \
+ && mkdir -p /var/log/pgbouncer /var/run/pgbouncer \
+ && chown -R postgres:postgres /var/run/pgbouncer /etc/pgbouncer
 
 USER postgres
 
 ENTRYPOINT ["/usr/local/bin/pgbouncer-entrypoint.sh"]
 CMD ["pgbouncer", "/etc/pgbouncer/pgbouncer.ini"]
-EXPOSE 5432
+EXPOSE 6432

--- a/docker/postgres
+++ b/docker/postgres
@@ -8,17 +8,16 @@ FROM postgres:17 AS base
 ########################
 FROM base AS final
 
-RUN apt-get update && apt-get -y install pgbackrest pgbadger cron sudo wget
-RUN apt-get -y install procps && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends pgbackrest pgbadger procps \
+ && rm -rf /var/lib/apt/lists/*
 
-RUN wget -P /usr/local/bin https://raw.githubusercontent.com/n3oltd/actions/main/docker/assets/postgres-entrypoint.sh
-RUN chmod +x /usr/local/bin/postgres-entrypoint.sh
+# COPY, not a RUN that fetches: a RUN's cache key is its command string, which never changes, so
+# a warm builder reuses the layer and ships whatever the entrypoint was when it was first built.
+COPY --chmod=0755 postgres-entrypoint.sh /usr/local/bin/postgres-entrypoint.sh
 
-RUN mkdir -p /var/lib/postgresql
-RUN chown -R postgres:postgres /var/lib/postgresql
-
-RUN mkdir -p /etc/pgbackrest
-RUN chown -R postgres:postgres /etc/pgbackrest
+RUN mkdir -p /var/lib/postgresql /etc/pgbackrest \
+ && chown -R postgres:postgres /var/lib/postgresql /etc/pgbackrest
 
 USER postgres
 


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

**This one matters before #168 is rolled out, because it is what makes #168 actually reach the image.**

A `RUN`'s cache key is its command string. Both Dockerfiles fetched their entrypoint with a constant `wget` URL, so a builder with a warm cache reuses that layer and the image ships whatever the entrypoint contained when the layer was first built. An entrypoint-only change reaches the registry only if something above it in the *same* Dockerfile also changed.

#168 is exactly that shape. It changed `docker/pgbouncer` and both entrypoints, but not `docker/postgres`. So on a warm builder the pgbouncer image picks up `auth_type = scram-sha-256` while the postgres image keeps seeding the agent roles as md5 — pgbouncer then demands SCRAM from a `pg_shadow` that still holds md5 hashes, and every agent login fails. Whether it bites depends on the runner's builder state, which is not something I can see, and it is cheap to remove as a variable.

Both entrypoints are now `COPY`ed from the build context. `COPY` is content-addressed, so changing an entrypoint invalidates that layer and everything after it. Both workflows fetch the entrypoint alongside the Dockerfile so it is in the context; they already did this for the Dockerfile itself, since the reusable workflow may be called from a repo that is not this one.

While in there, the postgres image drops three packages it does not use:

- `cron` — nothing installs a crontab. `crontab -l` on a live tenant reports none and `/etc/cron.d` holds only its placeholder; the backup jobs reach the database by `kubectl exec`, not cron.
- `sudo` — the container runs as uid 999 with no sudoers entry, so it is a setuid-root binary that cannot be used for its purpose but is available to anything that gets inside.
- `wget` — only ever there to fetch the entrypoint.

Installs move to `--no-install-recommends`, and the run of one-line `mkdir`/`chown` layers is folded together.

`docker/pgbouncer` exposed 5432 while listening on 6432.

Two things a reviewer should know rather than discover:

- **The `docker/postgres` diff looks larger than it is.** That file was the only one under `docker/` still using CRLF; everything beside it is LF and there is no `.gitattributes` normalising anything. It now matches its siblings. Beyond consistency, the multi-line `RUN` continuations introduced here want LF — `\` followed by `\r\n` is a known way to break a build.
- **The `postgres:17` base is deliberately untouched.** Bumping it to 18 has to follow the tenant migration, not precede it, because `GetLatestContainerImage` resolves `n3o-postgres:latest` at deploy time and an 18 binary will not open a 17 data directory. That bump is a later step in #3273.

## Test plan

- [x] Reproduced the cache behaviour: built a Dockerfile whose only fetch is that same `RUN wget`, built it twice, and the second build reports `CACHED` for the fetch layer — it does not re-run.
- [x] Confirmed the replacement behaves the other way: appended a canary line to the entrypoint, rebuilt, and the `COPY` layer rebuilt while the apt layer above it stayed cached. The canary was present in the image. Reverted.
- [x] Built both images from a context assembled the way the workflows assemble it (Dockerfile plus entrypoint at the context root).
- [x] Tooling survived `--no-install-recommends`: pgBackRest 2.59.0, pgBadger 13.2, procps 4.0.4 all run. pgBackRest is up from 2.58.0 as a side effect of the rebuild.
- [x] `cron`, `sudo` and `wget` are absent from the image; the entrypoint is present at 0755.
- [x] End-to-end smoke with both containers sharing a network namespace as they do in a pod: `n3o_agent_ro` authenticates through pgbouncer, a wrong password is rejected with `FATAL: SASL authentication failed`, pgbouncer reports 1.25.2.
- [ ] Neither image is rebuilt or deployed by merging this; the rollout is still the scheduled Pass 1 in #3273.
