### PR TITLE
Add the image that carries a tenant from PostgreSQL 17 to 18

### DIFF
--- a/.github/workflows/n3o-docker-build-push-postgres-upgrade.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres-upgrade.yml
@@ -1,0 +1,57 @@
+# Builds and pushes the N3O Postgres major-upgrade Docker image to ACR with date
+# and latest tags, fetching the Dockerfile from the actions repo. Takes no
+# inputs. Dispatchable, because the image is built for a migration rather than
+# on a pipeline.
+name: 'docker-build-push-postgres-upgrade'
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-push-docker-image-job:
+
+    runs-on: n3o-github-runner
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - id: buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: acr login
+        uses: docker/login-action@v4
+        with:
+          registry: n3oltd.azurecr.io
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: fetch dockerfile and script
+        shell: bash
+        run: |
+          curl -fsSL -o postgres-upgrade \
+            https://raw.githubusercontent.com/n3oltd/actions/main/docker/postgres-upgrade
+          curl -fsSL -o postgres-upgrade.sh \
+            https://raw.githubusercontent.com/n3oltd/actions/main/docker/assets/postgres-upgrade.sh
+
+      - id: meta-postgres-upgrade
+        name: prepare postgres-upgrade
+        run: |
+          DOCKER_IMAGE_NAME=n3o-postgres-upgrade
+          DOCKER_IMAGE=n3oltd.azurecr.io/$DOCKER_IMAGE_NAME
+          NOW=$(date -u +'%Y.%-m.%-d')
+          VERSION="$NOW.${{ github.run_number }}"
+          VERSIONTAG="${DOCKER_IMAGE}:${VERSION}"
+          LATESTTAG="${DOCKER_IMAGE}:latest"
+          echo "versiontag=$VERSIONTAG" >> $GITHUB_OUTPUT
+          echo "latesttag=$LATESTTAG" >> $GITHUB_OUTPUT
+
+      - name: build and push postgres-upgrade
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          target: final
+          file: postgres-upgrade
+          push: true
+          tags: ${{ steps.meta-postgres-upgrade.outputs.versiontag }} , ${{ steps.meta-postgres-upgrade.outputs.latesttag }}

--- a/docker/assets/postgres-upgrade.sh
+++ b/docker/assets/postgres-upgrade.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+OLD_BIN=/usr/lib/postgresql/17/bin
+NEW_BIN=/usr/lib/postgresql/18/bin
+
+: "${PGDATA:?PGDATA is required}"
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+# Read from the running cluster before it is stopped; pg_controldata stopped reporting locale in
+# 15, and pg_upgrade rejects a new cluster whose locale does not match the old one.
+: "${PG_LOCALE:?PG_LOCALE is required}"
+: "${PG_ENCODING:?PG_ENCODING is required}"
+
+NEW="${PGDATA}.new"
+RETAINED="${PGDATA}.pg17"
+
+die() { echo "postgres-upgrade: $*" >&2; exit 1; }
+control() { $OLD_BIN/pg_controldata -D "$PGDATA" | awk -F': +' -v k="$1" '$0 ~ k {print $2}'; }
+
+[ -f "$PGDATA/PG_VERSION" ] || die "no cluster at $PGDATA"
+version=$(cat "$PGDATA/PG_VERSION")
+[ "$version" = "17" ] || die "expected a version 17 cluster at $PGDATA, found $version"
+
+# Leftovers mean a previous run stopped partway. Resolving that is a judgement about which copy
+# holds the tenant's data, so it is never made here.
+[ -e "$RETAINED" ] && die "$RETAINED exists; a previous run left state behind"
+[ -e "$NEW" ] && die "$NEW exists; a previous run left state behind"
+
+state=$(control 'Database cluster state')
+[ "$state" = "shut down" ] || die "cluster state is '$state'; pg_upgrade needs a clean shutdown"
+
+used=$(du -sk "$PGDATA" | cut -f1)
+free=$(df -Pk "$(dirname "$PGDATA")" | awk 'NR==2 {print $4}')
+[ "$free" -gt "$used" ] || die "copy needs ${used}kB, volume has ${free}kB free"
+
+# 18 initdb turns checksums on and pg_upgrade refuses a mismatch. Enabling them on the old
+# cluster rather than disabling them on the new is the direction that gains something, and the
+# cluster is already stopped, which is the only time it can be done.
+if [ "$(control 'Data page checksum version')" = "0" ]; then
+  echo "postgres-upgrade: enabling data checksums"
+  $OLD_BIN/pg_checksums --enable -D "$PGDATA"
+fi
+
+trap 'rm -rf "$NEW"' ERR
+
+$NEW_BIN/initdb -D "$NEW" --locale="$PG_LOCALE" --encoding="$PG_ENCODING" -U "$POSTGRES_USER"
+
+cd /tmp
+for phase in --check ''; do
+  $NEW_BIN/pg_upgrade --old-bindir="$OLD_BIN" --new-bindir="$NEW_BIN" \
+                      --old-datadir="$PGDATA" --new-datadir="$NEW" \
+                      --username="$POSTGRES_USER" ${phase}
+done
+
+# initdb writes a narrower pg_hba than the image entrypoint does, and the entrypoint only writes
+# one for a data directory it created, so an upgraded cluster would silently stop accepting
+# anything but loopback.
+cp "$PGDATA/pg_hba.conf" "$PGDATA/pg_ident.conf" "$NEW/"
+
+trap - ERR
+
+mv "$PGDATA" "$RETAINED"
+mv "$NEW" "$PGDATA"
+
+echo "postgres-upgrade: $PGDATA is now $(cat "$PGDATA/PG_VERSION"); the previous cluster is at $RETAINED"

--- a/docker/postgres-upgrade
+++ b/docker/postgres-upgrade
@@ -1,0 +1,21 @@
+########################
+### base
+########################
+FROM postgres:18 AS base
+
+########################
+### final
+########################
+FROM base AS final
+
+# pg_upgrade needs both majors present at once. PGDG carries every supported version for trixie,
+# which is what the postgres image already builds on.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends postgresql-17 procps \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=0755 postgres-upgrade.sh /usr/local/bin/postgres-upgrade.sh
+
+USER postgres
+
+ENTRYPOINT ["/usr/local/bin/postgres-upgrade.sh"]


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

`pg_upgrade` needs both major versions on disk at once, which the tenant image cannot provide — it is built from a single `postgres` base. So this is a separate image, and deliberately a separate *name*: `GetLatestContainerImage` resolves `n3o-postgres:latest` at deploy time with nothing pinned, so publishing an 18-based tenant image before the tenants have moved would leave the next deploy of any of them unable to start. `n3o-postgres-upgrade` can be published whenever without touching what a tenant deploy resolves to.

The script runs as a Job with the database scaled to zero and the tenant's PVC mounted. It refuses unless it finds a version 17 cluster that is **cleanly shut down**, with no leftovers from an earlier run, and room on the volume for a second copy. Then it enables data checksums, `initdb`s the new cluster, runs `pg_upgrade` in check mode and then for real, and swaps the directories so the new cluster takes the canonical `$PGDATA` path and the old one is retained beside it as `$PGDATA.pg17`.

Two details the whole procedure rests on, both found by testing rather than reading:

**Checksums are enabled on the old cluster, not disabled on the new.** PostgreSQL 18's `initdb` turns data checksums on by default and `pg_upgrade` refuses a mismatch outright — `old cluster does not use data checksums but the new one does`. The estate's clusters have them off. Passing `--no-data-checksums` would satisfy `pg_upgrade` and preserve the status quo; enabling them on the old cluster satisfies it and leaves the tenant with silent-corruption detection it did not have. The cluster is already stopped, which is the only time this can be done at all.

**`pg_hba.conf` is copied across.** A fresh `initdb` writes only the loopback `trust` lines; the live clusters also carry `host all all all scram-sha-256`, which the image's own entrypoint adds — and the entrypoint only writes a `pg_hba` for a data directory it created. Without the copy, an upgraded tenant would come up looking healthy and quietly stop accepting anything but loopback. `pg_ident.conf` goes with it.

Locale and encoding are **required inputs rather than defaults**. `pg_controldata` stopped reporting them in 15, so they can only be read from a running cluster — before it is stopped — and `pg_upgrade` rejects a new cluster whose locale does not match. Every tenant is `en_US.utf8`/`UTF8` today, but hardcoding that would mean an unexpected tenant is silently upgraded into the wrong collation rather than failing.

The workflow is dispatchable as well as callable, since this image is built for a migration rather than on a pipeline.

## Test plan

Built the real `n3o-postgres` image from `main`, stood up a tenant-shaped 17.10 cluster on a volume — `en_US.utf8`, `unaccent`, 40,000 rows with a text index, the entrypoint's own `pg_hba` — shut it down cleanly, and ran the Job image against the volume.

- [x] Upgrade completed and reported the swap. Three seconds at this size; the checksum pass is the part that scales with data, and `6e` at 114 GB is the one to time on the pilot.
- [x] **Data byte-identical**: 40,000 rows and the same `md5` of the aggregated text column before and after.
- [x] `select version()` reports 18.4.
- [x] `data_checksums=on`, up from off.
- [x] `archive_mode=on`, `wal_level=replica`, `max_wal_senders=3` — the entrypoint re-applied them to the new data directory, which is the thing the handover warns is easy to lose.
- [x] `pg_hba.conf` ends with `host all all all scram-sha-256`, carried across.
- [x] `password_encryption=scram-sha-256`, and `log_connections=on` is still accepted on 18 despite the parameter gaining list values there.
- [x] Planner statistics survived — `reltuples` is 40000, not 0.
- [x] `unaccent` works.
- [x] The 17 cluster is retained beside the new one.
- [x] **Rollback proven**, not just claimed: renamed the directories back, started on the 17 image, and the data returned identical — same row count, same md5.

Guards, each triggered deliberately:

- [x] No `PG_LOCALE` → refuses before touching anything.
- [x] Cluster still running → `cluster state is 'in production'; pg_upgrade needs a clean shutdown`.
- [x] Already on 18 → `expected a version 17 cluster ... found 18`.
- [x] Leftovers from a previous run → refuses rather than guessing which copy holds the tenant's data.

- [ ] No tenant is touched by merging this. It publishes an image; running it against a tenant is the scheduled Pass 2 in #3273.
