### PR TITLE
Act on the review panel, and give the backup jobs an image with a shell

### DIFF
--- a/.github/workflows/n3o-docker-build-push-kubectl.yml
+++ b/.github/workflows/n3o-docker-build-push-kubectl.yml
@@ -1,8 +1,6 @@
-# Builds and pushes the N3O Postgres major-upgrade Docker image to ACR with date
-# and latest tags, fetching the Dockerfile from the actions repo. Takes no
-# inputs. Dispatchable, because the image is built for a migration rather than
-# on a pipeline.
-name: 'docker-build-push-postgres-upgrade'
+# Builds and pushes the N3O kubectl Docker image to ACR with date and latest
+# tags, fetching the Dockerfile from the actions repo. Takes no inputs.
+name: 'docker-build-push-kubectl'
 
 on:
   workflow_call:
@@ -26,18 +24,16 @@ jobs:
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
-      - name: fetch dockerfile and entrypoint
+      - name: fetch dockerfile
         shell: bash
         run: |
-          curl -fsSL -o postgres-upgrade \
-            https://raw.githubusercontent.com/n3oltd/actions/main/docker/postgres-upgrade
-          curl -fsSL -o postgres-upgrade.sh \
-            https://raw.githubusercontent.com/n3oltd/actions/main/docker/assets/postgres-upgrade.sh
+          curl -fsSL -o kubectl \
+            https://raw.githubusercontent.com/n3oltd/actions/main/docker/kubectl
 
-      - id: meta-postgres-upgrade
-        name: prepare postgres-upgrade
+      - id: meta-kubectl
+        name: prepare kubectl
         run: |
-          DOCKER_IMAGE_NAME=n3o-postgres-upgrade
+          DOCKER_IMAGE_NAME=n3o-kubectl
           DOCKER_IMAGE=n3oltd.azurecr.io/$DOCKER_IMAGE_NAME
           NOW=$(date -u +'%Y.%-m.%-d')
           VERSION="$NOW.${{ github.run_number }}"
@@ -46,12 +42,12 @@ jobs:
           echo "versiontag=$VERSIONTAG" >> $GITHUB_OUTPUT
           echo "latesttag=$LATESTTAG" >> $GITHUB_OUTPUT
 
-      - name: build and push postgres-upgrade
+      - name: build and push kubectl
         uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           target: final
-          file: postgres-upgrade
+          file: kubectl
           push: true
-          tags: ${{ steps.meta-postgres-upgrade.outputs.versiontag }} , ${{ steps.meta-postgres-upgrade.outputs.latesttag }}
+          tags: ${{ steps.meta-kubectl.outputs.versiontag }} , ${{ steps.meta-kubectl.outputs.latesttag }}

--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -29,9 +29,8 @@ sed -i "/log_lock_waits/d" /var/lib/postgresql/data/postgres/postgresql.conf
   
 } >> /var/lib/postgresql/data/postgres/postgresql.conf
 
-# These three delete the ssl settings written immediately above, because /ssl/d matches them
-# too. Every tenant therefore runs with ssl off. Removing them turns TLS on across every live
-# database at once, so it needs its own change rather than a quiet fix here.
+# /ssl/d matches the settings written above, so every tenant runs with ssl off; removing these
+# turns TLS on across every live database at once.
 sed -i "/ssl/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/ssl_cert_file/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/ssl_key_file/d" /var/lib/postgresql/data/postgres/postgresql.conf
@@ -95,8 +94,8 @@ until pg_isready -U "${POSTGRES_USER}" -d :"${POSTGRES_USER}"; do
   sleep 2
 done
 
-# Seed the read-only / read-write agent roles (idempotent). auth_query hands pgbouncer whatever
-# pg_authid holds, so this encryption and pgbouncer's auth_type have to agree.
+# auth_query hands pgbouncer whatever pg_authid holds, so this encryption and pgbouncer's
+# auth_type have to agree.
 if [ -n "${AGENT_RO_PASSWORD}" ] && [ -n "${AGENT_RW_PASSWORD}" ]; then
   psql -U "${POSTGRES_USER}" -d postgres -v ro_pw="${AGENT_RO_PASSWORD}" -v rw_pw="${AGENT_RW_PASSWORD}" <<'EOSQL'
 SET password_encryption = 'scram-sha-256';

--- a/docker/assets/postgres-upgrade.sh
+++ b/docker/assets/postgres-upgrade.sh
@@ -21,8 +21,7 @@ control() { $OLD_BIN/pg_controldata -D "$PGDATA" | awk -F': +' -v k="$1" '$0 ~ k
 version=$(cat "$PGDATA/PG_VERSION")
 [ "$version" = "17" ] || die "expected a version 17 cluster at $PGDATA, found $version"
 
-# Leftovers mean a previous run stopped partway. Resolving that is a judgement about which copy
-# holds the tenant's data, so it is never made here.
+# Resolving leftovers is a judgement about which copy holds the tenant's data, never made here.
 [ -e "$RETAINED" ] && die "$RETAINED exists; a previous run left state behind"
 [ -e "$NEW" ] && die "$NEW exists; a previous run left state behind"
 
@@ -33,9 +32,8 @@ used=$(du -sk "$PGDATA" | cut -f1)
 free=$(df -Pk "$(dirname "$PGDATA")" | awk 'NR==2 {print $4}')
 [ "$free" -gt "$used" ] || die "copy needs ${used}kB, volume has ${free}kB free"
 
-# 18 initdb turns checksums on and pg_upgrade refuses a mismatch. Enabling them on the old
-# cluster rather than disabling them on the new is the direction that gains something, and the
-# cluster is already stopped, which is the only time it can be done.
+# 18's initdb turns checksums on and pg_upgrade refuses a mismatch; a stopped cluster is the
+# only time they can be enabled.
 if [ "$(control 'Data page checksum version')" = "0" ]; then
   echo "postgres-upgrade: enabling data checksums"
   $OLD_BIN/pg_checksums --enable -D "$PGDATA"
@@ -45,12 +43,10 @@ trap 'rm -rf "$NEW"' ERR
 
 $NEW_BIN/initdb -D "$NEW" --locale="$PG_LOCALE" --encoding="$PG_ENCODING" -U "$POSTGRES_USER"
 
-cd /tmp
-for phase in --check ''; do
-  $NEW_BIN/pg_upgrade --old-bindir="$OLD_BIN" --new-bindir="$NEW_BIN" \
-                      --old-datadir="$PGDATA" --new-datadir="$NEW" \
-                      --username="$POSTGRES_USER" ${phase}
-done
+upgrade=("$NEW_BIN/pg_upgrade" --old-bindir="$OLD_BIN" --new-bindir="$NEW_BIN"
+         --old-datadir="$PGDATA" --new-datadir="$NEW" --username="$POSTGRES_USER")
+"${upgrade[@]}" --check
+"${upgrade[@]}"
 
 # initdb writes a narrower pg_hba than the image entrypoint does, and the entrypoint only writes
 # one for a data directory it created, so an upgraded cluster would silently stop accepting

--- a/docker/assets/postgres-upgrade.sh
+++ b/docker/assets/postgres-upgrade.sh
@@ -6,8 +6,8 @@ NEW_BIN=/usr/lib/postgresql/18/bin
 
 : "${PGDATA:?PGDATA is required}"
 : "${POSTGRES_USER:?POSTGRES_USER is required}"
-# Read from the running cluster before it is stopped; pg_controldata stopped reporting locale in
-# 15, and pg_upgrade rejects a new cluster whose locale does not match the old one.
+# pg_controldata stopped reporting locale in 15, and pg_upgrade accepts a mismatch silently, so
+# the guard below is the only thing standing between a wrong value and changed lc_* settings.
 : "${PG_LOCALE:?PG_LOCALE is required}"
 : "${PG_ENCODING:?PG_ENCODING is required}"
 
@@ -16,6 +16,14 @@ RETAINED="${PGDATA}.pg17"
 
 die() { echo "postgres-upgrade: $*" >&2; exit 1; }
 control() { $OLD_BIN/pg_controldata -D "$PGDATA" | awk -F': +' -v k="$1" '$0 ~ k {print $2}'; }
+
+# Only an interruption between the two renames produces this, and the new cluster is complete by
+# then. Leaving it is the dangerous option: the entrypoint reads an absent PGDATA as a new tenant.
+if [ ! -e "$PGDATA" ] && [ -d "$NEW" ] && [ -d "$RETAINED" ]; then
+  mv "$NEW" "$PGDATA"
+  echo "postgres-upgrade: completed the interrupted rename; $PGDATA is now $(cat "$PGDATA/PG_VERSION")"
+  exit 0
+fi
 
 [ -f "$PGDATA/PG_VERSION" ] || die "no cluster at $PGDATA"
 version=$(cat "$PGDATA/PG_VERSION")
@@ -28,9 +36,15 @@ version=$(cat "$PGDATA/PG_VERSION")
 state=$(control 'Database cluster state')
 [ "$state" = "shut down" ] || die "cluster state is '$state'; pg_upgrade needs a clean shutdown"
 
-used=$(du -sk "$PGDATA" | cut -f1)
+old_locale=$(sed -n "s/^lc_monetary = '\([^']*\)'.*/\1/p" "$PGDATA/postgresql.conf" | tail -1)
+[ -z "$old_locale" ] || [ "$old_locale" = "$PG_LOCALE" ] \
+  || die "PG_LOCALE is '$PG_LOCALE' but the cluster was built with '$old_locale'"
+
+# pg_upgrade copies neither pg_wal nor log, and log accumulates pgBadger reports without bound.
+# The margin covers the new cluster's initdb footprint and the WAL its schema restore generates.
+used=$(du -sk --exclude=pg_wal --exclude=log "$PGDATA" | cut -f1)
 free=$(df -Pk "$(dirname "$PGDATA")" | awk 'NR==2 {print $4}')
-[ "$free" -gt "$used" ] || die "copy needs ${used}kB, volume has ${free}kB free"
+[ "$free" -gt $((used * 12 / 10)) ] || die "copy needs ${used}kB plus margin, volume has ${free}kB free"
 
 # 18's initdb turns checksums on and pg_upgrade refuses a mismatch; a stopped cluster is the
 # only time they can be enabled.
@@ -43,6 +57,8 @@ trap 'rm -rf "$NEW"' ERR
 
 $NEW_BIN/initdb -D "$NEW" --locale="$PG_LOCALE" --encoding="$PG_ENCODING" -U "$POSTGRES_USER"
 
+# errexit exempts the left of &&, so joining these would skip the trap and fall through to the
+# renames with an empty cluster.
 upgrade=("$NEW_BIN/pg_upgrade" --old-bindir="$OLD_BIN" --new-bindir="$NEW_BIN"
          --old-datadir="$PGDATA" --new-datadir="$NEW" --username="$POSTGRES_USER")
 "${upgrade[@]}" --check
@@ -58,4 +74,14 @@ trap - ERR
 mv "$PGDATA" "$RETAINED"
 mv "$NEW" "$PGDATA"
 
-echo "postgres-upgrade: $PGDATA is now $(cat "$PGDATA/PG_VERSION"); the previous cluster is at $RETAINED"
+cat <<EOF
+postgres-upgrade: $PGDATA is now $(cat "$PGDATA/PG_VERSION"); the previous cluster is at $RETAINED
+
+pg_upgrade assigned a new system identifier, so pgBackRest will reject every WAL segment this
+cluster archives until its stanza is repointed. Until that is done there is no PITR and pg_wal
+cannot recycle. Once the pod is serving, run against it:
+
+  pgbackrest --stanza=n3o stanza-upgrade
+  pgbackrest --stanza=n3o --type=full backup
+  pgbackrest --stanza=n3o check
+EOF

--- a/docker/kubectl
+++ b/docker/kubectl
@@ -1,0 +1,31 @@
+########################
+### base
+########################
+FROM debian:trixie-slim AS base
+
+########################
+### final
+########################
+FROM base AS final
+
+# The upstream kubectl image is distroless, which suits a container whose command is kubectl and
+# nothing else. The jobs that use this one are shell scripts that also report their outcome over
+# HTTP, so they need a shell and curl.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+ && curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.36/deb/Release.key \
+      | gpg --dearmor -o /etc/apt/keyrings/kubernetes.gpg \
+ && echo "deb [signed-by=/etc/apt/keyrings/kubernetes.gpg] https://pkgs.k8s.io/core:/stable:/v1.36/deb/ /" \
+      > /etc/apt/sources.list.d/kubernetes.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends kubectl \
+ && apt-get purge -y gnupg \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --uid 65532 --create-home --shell /bin/bash nonroot
+
+USER nonroot
+WORKDIR /home/nonroot
+
+CMD ["/bin/bash"]

--- a/docker/pgbouncer
+++ b/docker/pgbouncer
@@ -19,8 +19,6 @@ RUN apt-get update \
 
 WORKDIR /etc/pgbouncer
 
-# COPY, not a RUN that fetches: a RUN's cache key is its command string, which never changes, so
-# a warm builder reuses the layer and ships whatever the entrypoint was when it was first built.
 COPY --chmod=0755 pgbouncer-entrypoint.sh /usr/local/bin/pgbouncer-entrypoint.sh
 
 RUN touch /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt \

--- a/docker/postgres
+++ b/docker/postgres
@@ -12,8 +12,6 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends pgbackrest pgbadger procps \
  && rm -rf /var/lib/apt/lists/*
 
-# COPY, not a RUN that fetches: a RUN's cache key is its command string, which never changes, so
-# a warm builder reuses the layer and ships whatever the entrypoint was when it was first built.
 COPY --chmod=0755 postgres-entrypoint.sh /usr/local/bin/postgres-entrypoint.sh
 
 RUN mkdir -p /var/lib/postgresql /etc/pgbackrest \

--- a/docker/postgres-upgrade
+++ b/docker/postgres-upgrade
@@ -8,11 +8,14 @@ FROM postgres:18 AS base
 ########################
 FROM base AS final
 
-# pg_upgrade needs both majors present at once. PGDG carries every supported version for trixie,
-# which is what the postgres image already builds on.
+# pg_upgrade needs both majors present at once.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends postgresql-17 procps \
  && rm -rf /var/lib/apt/lists/*
+
+# pg_upgrade writes its logs and its delete_old_cluster.sh into the working directory, and the
+# base image leaves it at / where the postgres user cannot write.
+WORKDIR /tmp
 
 COPY --chmod=0755 postgres-upgrade.sh /usr/local/bin/postgres-upgrade.sh
 


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

Panel review of #168, #169 and #170, plus one thing the review work turned up that matters more than any of the findings.

### The backup jobs are one deploy away from stopping

The backup CronJobs run `command: [/bin/sh, -c, ...]`. The image the template names, `registry.k8s.io/kubectl:v1.36.2`, is **distroless and has no `/bin/sh` on any architecture** — I checked amd64 as well as arm64. The live CronJobs are running `bitnami/kubectl:latest` instead, which does have a shell. That is manifest drift, and here it is load-bearing: the next `n3o deploy postgres server` would replace a working image with one whose container cannot start, and **every backup across all 36 tenants would stop** — silently, because nothing alerts.

`n3o-kubectl` replaces both. It has a shell, a kubectl pinned to the cluster's 1.36 line rather than `:latest` on a third-party image, and `curl` — which is also what lets the jobs report a failure to Sentry instead of failing where nobody looks. It runs as a non-root user; neither image it replaces does. The template change that consumes it is a separate PR in `n3oltd/backend`, and this has to land first.

### Comment policy

Everything the panel could not justify is gone. Twelve comment lines become six.

The decisive argument on the two `COPY` comments was one I had missed: `docker/postgres-upgrade` does the identical `COPY --chmod=0755` with no comment at all, so the other two were not explaining anything the third needed explaining. They were also backward-looking — "COPY, not a RUN that fetches" defines the line against the implementation it replaced, which is the commit message's job.

The rest, each cut to the constraint alone: the `ssl` comment lost a sentence restating the three `sed`s beneath it and a trailing clause about a future change; the role-seeding comment lost "Seed the read-only / read-write agent roles (idempotent)", which the `CREATE ROLE ... IF NOT EXISTS` block below states literally; the checksum comment lost a clause weighing the road not taken, which belongs in the commit message and is already there; the leftovers comment lost a sentence duplicating the `die` string on the next line; and `docker/postgres-upgrade` no longer pins a Debian codename that changes with its base image.

### Two that are not about comments

**`pg_upgrade` was invoked through a loop.** `for phase in --check ''` relied on an unquoted `${phase}` vanishing on the second pass. It worked, but it is the only unquoted expansion in an otherwise rigorously quoted file, shellcheck flags it as SC2086, and the obvious "fix" — adding quotes — would pass `pg_upgrade` an empty argument. It is now an array of the shared arguments and two explicit calls, which needs no comment to defend.

**`cd /tmp` is now `WORKDIR /tmp` on the image**, which is where `docker/pgbouncer` already establishes that this is said. It was load-bearing and unexplained: I confirmed `postgres:18` leaves `WorkingDir` empty, so the container starts in `/`, the postgres user gets `Permission denied` writing there, and `pg_upgrade` writes its logs and `delete_old_cluster.sh` into the working directory.

### Flagged by the panel, deliberately not done here

The three sibling scripts have three different strictness levels — `postgres-entrypoint.sh` sets nothing, `pgbouncer-entrypoint.sh` sets `set -e`, `postgres-upgrade.sh` sets `set -euo pipefail`. The new script is the right end state and the tenant entrypoint is the outlier, but converging it changes behaviour on 36 live tenants: today a failure in the role-seeding block is ignored and the server carries on. That deserves its own change and its own test, not a quiet ride along with a comment cleanup.

## Test plan

- [x] All three scripts parse (`bash -n`).
- [x] Rebuilt both images and re-ran the full 17.10 → 18.4 upgrade against a tenant-shaped cluster after the array and WORKDIR changes: data identical (40,000 rows, same md5 before and after), `server_version` 18.4, `archive_mode=on`, `data_checksums=on`, `pg_hba.conf` still ends with `host all all all scram-sha-256`.
- [x] Guards still fire after the refactor.
- [x] Confirmed `docker image inspect postgres:18` reports an empty `WorkingDir`, and that the postgres user cannot write to `/` — so the `cd` really was doing work.
- [x] Confirmed `registry.k8s.io/kubectl:v1.36.2` has no `/bin/sh` on `linux/amd64`, and that `bitnami/kubectl:latest` does.
- [x] Built `n3o-kubectl` for `linux/amd64` and ran it as the non-root user: `kubectl version --client` reports v1.36.3, `curl` 8.14.1 present, `$HOME` writable so kubectl's cache works, `kubectl config view` runs clean. 219 MB.
- [ ] No image is rebuilt and no tenant is touched by merging this.
