### PR TITLE
Stop writing role passwords into the query log, and repair an md5 superuser

### DIFF
--- a/docker/assets/pgbouncer-entrypoint.sh
+++ b/docker/assets/pgbouncer-entrypoint.sh
@@ -8,8 +8,7 @@ AUTH_FILE="${PG_CONFIG_DIR}/userlist.txt"
 
 mkdir -p "$PG_CONFIG_DIR"
 
-# No credential is needed here: postgres shares the pod's network namespace and pg_hba grants
-# trust on 127.0.0.1.
+# No credential needed: postgres shares the pod's netns and pg_hba grants trust on 127.0.0.1.
 until pg_isready -h "${HOST}" -p "${PORT}" -U "${POSTGRES_USER}" >/dev/null 2>&1; do
   echo "Waiting for Postgres before reading the SCRAM verifier..."
   sleep 2
@@ -18,8 +17,7 @@ done
 VERIFIER=$(psql -h "${HOST}" -p "${PORT}" -U "${POSTGRES_USER}" -d postgres -tAc \
   "SELECT rolpassword FROM pg_authid WHERE rolname = current_user")
 
-# Naming the scheme rather than showing the value: an md5 secret is md5(password||username), so
-# any prefix of it confirms a candidate in an offline attack.
+# Any prefix of an md5 secret confirms a candidate offline, so name the scheme, not the value.
 if [[ "$VERIFIER" != SCRAM-SHA-256\$* ]]; then
   case "$VERIFIER" in
     md5*) scheme="an md5" ;;
@@ -30,8 +28,7 @@ if [[ "$VERIFIER" != SCRAM-SHA-256\$* ]]; then
   exit 1
 fi
 
-# Only the admin console reads this; application logins go through auth_query. A verifier cannot
-# be replayed into a login, so nothing password-equivalent lands on disk.
+# Only the admin console reads this, and a verifier cannot be replayed into a login.
 umask 077
 printf '"%s" "%s"\n' "${POSTGRES_USER}" "${VERIFIER}" > "$AUTH_FILE"
 

--- a/docker/assets/pgbouncer-entrypoint.sh
+++ b/docker/assets/pgbouncer-entrypoint.sh
@@ -18,8 +18,15 @@ done
 VERIFIER=$(psql -h "${HOST}" -p "${PORT}" -U "${POSTGRES_USER}" -d postgres -tAc \
   "SELECT rolpassword FROM pg_authid WHERE rolname = current_user")
 
+# Naming the scheme rather than showing the value: an md5 secret is md5(password||username), so
+# any prefix of it confirms a candidate in an offline attack.
 if [[ "$VERIFIER" != SCRAM-SHA-256\$* ]]; then
-  echo "No SCRAM verifier for ${POSTGRES_USER} (got '${VERIFIER:0:16}'); refusing to start." >&2
+  case "$VERIFIER" in
+    md5*) scheme="an md5" ;;
+    "")   scheme="no" ;;
+    *)    scheme="an unrecognised" ;;
+  esac
+  echo "${POSTGRES_USER} holds ${scheme} secret, not a SCRAM verifier; refusing to start." >&2
   exit 1
 fi
 

--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -65,6 +65,9 @@ mkdir /etc/pgbackrest/backup-repo
   echo "start-fast=y"
 } >> /etc/pgbackrest/pgbackrest.conf
 
+# Holds the repository cipher passphrase and the storage account key.
+chmod 600 /etc/pgbackrest/pgbackrest.conf
+
 # Unit of tcp_keepalives_idle is seconds and idle_session_timeout is milliseconds
 exec docker-entrypoint.sh postgres \
           -c archive_mode=on \
@@ -94,10 +97,25 @@ until pg_isready -U "${POSTGRES_USER}" -d :"${POSTGRES_USER}"; do
   sleep 2
 done
 
+# log_min_duration_statement is 0, and PostgreSQL does not redact ALTER ROLE, so without these
+# two settings every password below is written verbatim into log/ — inside PGDATA, and so into
+# every pgBackRest backup of it.
+#
 # auth_query hands pgbouncer whatever pg_authid holds, so this encryption and pgbouncer's
-# auth_type have to agree.
+# auth_type have to agree. docker-entrypoint sets the superuser's password only when it creates
+# the data directory, so a cluster first built under a release whose default was md5 keeps an md5
+# secret indefinitely, and pgbouncer refuses to start against one.
+psql -U "${POSTGRES_USER}" -d postgres -v role="${POSTGRES_USER}" -v su_pw="${POSTGRES_PASSWORD}" <<'EOSQL'
+SET log_min_duration_statement = -1;
+SET log_statement = 'none';
+SET password_encryption = 'scram-sha-256';
+ALTER ROLE :"role" PASSWORD :'su_pw';
+EOSQL
+
 if [ -n "${AGENT_RO_PASSWORD}" ] && [ -n "${AGENT_RW_PASSWORD}" ]; then
   psql -U "${POSTGRES_USER}" -d postgres -v ro_pw="${AGENT_RO_PASSWORD}" -v rw_pw="${AGENT_RW_PASSWORD}" <<'EOSQL'
+SET log_min_duration_statement = -1;
+SET log_statement = 'none';
 SET password_encryption = 'scram-sha-256';
 DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'n3o_agent_ro') THEN CREATE ROLE n3o_agent_ro LOGIN; END IF; END $$;
 DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'n3o_agent_rw') THEN CREATE ROLE n3o_agent_rw LOGIN; END IF; END $$;

--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -29,8 +29,7 @@ sed -i "/log_lock_waits/d" /var/lib/postgresql/data/postgres/postgresql.conf
   
 } >> /var/lib/postgresql/data/postgres/postgresql.conf
 
-# /ssl/d matches the settings written above, so every tenant runs with ssl off; removing these
-# turns TLS on across every live database at once.
+# /ssl/d matches the three settings written above, so every tenant runs with ssl off.
 sed -i "/ssl/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/ssl_cert_file/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/ssl_key_file/d" /var/lib/postgresql/data/postgres/postgresql.conf
@@ -65,7 +64,6 @@ mkdir /etc/pgbackrest/backup-repo
   echo "start-fast=y"
 } >> /etc/pgbackrest/pgbackrest.conf
 
-# Holds the repository cipher passphrase and the storage account key.
 chmod 600 /etc/pgbackrest/pgbackrest.conf
 
 # Unit of tcp_keepalives_idle is seconds and idle_session_timeout is milliseconds
@@ -97,14 +95,8 @@ until pg_isready -U "${POSTGRES_USER}" -d :"${POSTGRES_USER}"; do
   sleep 2
 done
 
-# log_min_duration_statement is 0, and PostgreSQL does not redact ALTER ROLE, so without these
-# two settings every password below is written verbatim into log/ — inside PGDATA, and so into
-# every pgBackRest backup of it.
-#
-# auth_query hands pgbouncer whatever pg_authid holds, so this encryption and pgbouncer's
-# auth_type have to agree. docker-entrypoint sets the superuser's password only when it creates
-# the data directory, so a cluster first built under a release whose default was md5 keeps an md5
-# secret indefinitely, and pgbouncer refuses to start against one.
+# Unlogged: ALTER ROLE is not redacted and log/ sits inside PGDATA, which is backed up. The
+# superuser is rewritten because docker-entrypoint sets it only at initdb; pgbouncer needs SCRAM.
 psql -U "${POSTGRES_USER}" -d postgres -v role="${POSTGRES_USER}" -v su_pw="${POSTGRES_PASSWORD}" <<'EOSQL'
 SET log_min_duration_statement = -1;
 SET log_statement = 'none';

--- a/docker/assets/postgres-upgrade.sh
+++ b/docker/assets/postgres-upgrade.sh
@@ -40,8 +40,7 @@ old_locale=$(sed -n "s/^lc_monetary = '\([^']*\)'.*/\1/p" "$PGDATA/postgresql.co
 [ -z "$old_locale" ] || [ "$old_locale" = "$PG_LOCALE" ] \
   || die "PG_LOCALE is '$PG_LOCALE' but the cluster was built with '$old_locale'"
 
-# pg_upgrade copies neither pg_wal nor log, and log accumulates pgBadger reports without bound.
-# The margin covers the new cluster's initdb footprint and the WAL its schema restore generates.
+# pg_upgrade copies neither pg_wal nor log; the margin covers the new cluster's own footprint.
 used=$(du -sk --exclude=pg_wal --exclude=log "$PGDATA" | cut -f1)
 free=$(df -Pk "$(dirname "$PGDATA")" | awk 'NR==2 {print $4}')
 [ "$free" -gt $((used * 12 / 10)) ] || die "copy needs ${used}kB plus margin, volume has ${free}kB free"
@@ -57,16 +56,13 @@ trap 'rm -rf "$NEW"' ERR
 
 $NEW_BIN/initdb -D "$NEW" --locale="$PG_LOCALE" --encoding="$PG_ENCODING" -U "$POSTGRES_USER"
 
-# errexit exempts the left of &&, so joining these would skip the trap and fall through to the
-# renames with an empty cluster.
+# errexit exempts the left of &&, so joining these would skip the trap and reach the renames.
 upgrade=("$NEW_BIN/pg_upgrade" --old-bindir="$OLD_BIN" --new-bindir="$NEW_BIN"
          --old-datadir="$PGDATA" --new-datadir="$NEW" --username="$POSTGRES_USER")
 "${upgrade[@]}" --check
 "${upgrade[@]}"
 
-# initdb writes a narrower pg_hba than the image entrypoint does, and the entrypoint only writes
-# one for a data directory it created, so an upgraded cluster would silently stop accepting
-# anything but loopback.
+# initdb writes a narrower pg_hba, and the entrypoint only writes one for a directory it made.
 cp "$PGDATA/pg_hba.conf" "$PGDATA/pg_ident.conf" "$NEW/"
 
 trap - ERR

--- a/docker/kubectl
+++ b/docker/kubectl
@@ -8,9 +8,7 @@ FROM debian:trixie-slim AS base
 ########################
 FROM base AS final
 
-# The upstream kubectl image is distroless, which suits a container whose command is kubectl and
-# nothing else. The jobs that use this one are shell scripts that also report their outcome over
-# HTTP, so they need a shell and curl.
+# The upstream image is distroless; the jobs using this one are shell scripts that report over HTTP.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
  && curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.36/deb/Release.key \

--- a/docker/postgres-upgrade
+++ b/docker/postgres-upgrade
@@ -13,8 +13,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends postgresql-17 procps \
  && rm -rf /var/lib/apt/lists/*
 
-# pg_upgrade writes its logs and its delete_old_cluster.sh into the working directory, and the
-# base image leaves it at / where the postgres user cannot write.
+# pg_upgrade writes into the working directory, which the base image leaves at / and unwritable.
 WORKDIR /tmp
 
 COPY --chmod=0755 postgres-upgrade.sh /usr/local/bin/postgres-upgrade.sh


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

Security review of #168. The central claim held up — the reviewer extracted the SCRAM verifier from a running container and could not use it to authenticate on any of three paths (pooled database, admin console, or PostgreSQL directly over a non-loopback address), where the real password succeeds on all three. The md5 hash it replaced *was* directly replayable. Two things it found alongside that are worth more than the claim.

### Role passwords were being written to the query log, and into every backup

`log_min_duration_statement` is `0` and PostgreSQL does not redact `ALTER ROLE`, so each pod start wrote both agent passwords in cleartext:

```
LOG: duration: 1.885 ms statement: ALTER ROLE n3o_agent_ro PASSWORD '<literal>'
```

`log_directory` is relative, so that lands in `log/` **inside PGDATA** — and pgBackRest includes `log/` in the backup manifest. The reviewer decompressed a backed-up log out of a real repository and found the password inside. Production retention is 90 days of full backups in Azure Blob.

**I confirmed this on the live estate**: `postgres-qa`, `postgres-prod`, `postgres-6e` and `postgres-65` each currently carry the statements in their on-disk logs. The reports CronJob prunes `postgresql-*.log` older than yesterday, so the on-disk window is short — the backups are the exposure, and each pod restart adds another pair.

This is pre-existing rather than introduced by #168, but this PR adds the superuser password to the same block, so the suppression had to land with it. Both seeding blocks now set `log_min_duration_statement = -1` and `log_statement = 'none'` for their own connection.

**This warrants a decision from you separately: the agent role passwords should be treated as disclosed and rotated.** They are in `CredentialsStore.Postgres` and in every backup taken to date.

### pgbouncer's precondition could never become true on its own

#168 made pgbouncer refuse to start unless the superuser holds a SCRAM verifier, and nothing was making that so. `docker-entrypoint` sets that password only when it creates the data directory; `-c password_encryption=scram-sha-256` governs later writes only; and the seeding block covered `n3o_agent_ro`/`n3o_agent_rw` alone. A cluster first built when md5 was the default would keep an md5 secret indefinitely, and `postgres-upgrade.sh` carries it across verbatim. The reviewer reproduced the consequence: pgbouncer exits 1 immediately, and since applications reach the database only through it, the tenant is unreachable and stays that way — CrashLoopBackOff.

**I checked all 36 tenants and every one holds a SCRAM superuser today**, so this was never going to fire in production. But a guard that refuses without being able to repair is the wrong shape, and it would have found a restored-from-old-backup tenant. The superuser is now rewritten alongside the agent roles, deliberately outside the `[ -n "$AGENT_RO_PASSWORD" ]` guard so it does not depend on variables that have nothing to do with it.

### The refusal message published credential material

It printed `${VERIFIER:0:16}` of whatever it found. On an md5 secret that is thirteen hex characters of `md5(password||username)` with the username on the same line — enough to confirm a candidate in an offline attack — and it repeats on every restart, so exactly in the state above it would loop forever into `kubectl logs`. It now names the scheme and not the value.

My first attempt at that fix was worse than the original: `${VERIFIER%%$*}` has no `$` to strip on an md5 secret, so it would have printed the whole hash.

### And one line

`pgbackrest.conf` was `0644` while holding `repo1-cipher-pass` and `repo1-azure-key` — the passphrase that decrypts the backups, beside the data whose backups contain the plaintext role passwords.

## Not fixed, and why

**Passwords in argv.** `psql -v ro_pw=...` is visible in `/proc/<pid>/cmdline`, and `procps` is installed. The alternatives are worse: interpolating into a heredoc removes psql's `:'var'` quoting and introduces an injection path for a generated password. The reviewer rated it low on the grounds that anything able to read `/proc` inside that container already has `trust` superuser access over loopback, and I agree.

**Offline crackability of the verifier.** SCRAM verifiers are PBKDF2-HMAC-SHA256 at PostgreSQL's default 4096 iterations. Better than md5, not immune. Raising `scram_iterations` is a separate change with its own connection-cost trade-off.

## Test plan

Built both images and ran the pair sharing a network namespace, with a cluster deliberately forced into the md5 state that could not previously self-repair.

- [x] Forced the superuser to md5 via `SET password_encryption='md5'` — confirmed the stored secret reads `md5`.
- [x] Restarted the container: the entrypoint repaired it to `SCRAM-SHA-256`, and both agent roles with it.
- [x] **Zero** occurrences of either canary password in `log/`, and **zero** `ALTER ROLE` statements logged at all. Before the change the same test logged them verbatim.
- [x] pgbouncer starts against the repaired cluster (`running`, exit 0) and `n3o_agent_ro` authenticates through it.
- [x] `pgbackrest.conf` is `600`.
- [x] Forced md5 back and started pgbouncer against it: `postgres-6e holds an md5 secret, not a SCRAM verifier; refusing to start.` — scheme named, no value.
- [x] Fleet check across all 36 live tenants: every superuser is already SCRAM, both agent roles are md5 everywhere and will be rewritten on their first restart under this image.
- [ ] No image is rebuilt and no tenant is touched by merging this.
