### PR TITLE
Let the postgres and pgbouncer images be built on demand

### DIFF
--- a/.github/workflows/n3o-docker-build-push-pgbouncer.yml
+++ b/.github/workflows/n3o-docker-build-push-pgbouncer.yml
@@ -5,6 +5,7 @@ name: 'docker-build-push-pgbouncer'
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   build-push-docker-image-job:

--- a/.github/workflows/n3o-docker-build-push-postgres.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres.yml
@@ -5,6 +5,7 @@ name: 'docker-build-push-postgres'
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   build-push-docker-image-job:


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

`n3o-docker-build-push-postgres` and `-pgbouncer` declare only `workflow_call`, and nothing in this repository calls either. Rebuilding either image therefore had no direct route. The `postgres-upgrade` and `kubectl` workflows added in #170 and #171 already carry `workflow_dispatch`; this brings the two older ones in line.

Both images need rebuilding before Pass 1 of #3273 — the SCRAM change in #168, the build-cache fix in #169 and the password-logging fix in #172 all sit in entrypoints that only reach the registry on a rebuild.

Worth recording, because it governs the rollout order: `ContainerRegistry.GetLatestContainerImage` resolves by newest manifest rather than by the `latest` tag, so publishing an image arms the next `n3o deploy postgres server` whether or not anything is tagged `latest`. Building is safe; the deploy is the step that takes tenants offline.

## Test plan

- [x] Both files parse as YAML and the only change is the added trigger.
- [ ] Merging this builds nothing on its own.