### PR TITLE
Build the images on hosted runners, and take a client name out of a public repo

### DIFF
--- a/.github/workflows/n3o-docker-build-push-kubectl.yml
+++ b/.github/workflows/n3o-docker-build-push-kubectl.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   build-push-docker-image-job:
 
-    runs-on: n3o-github-runner
+    # GitHub-hosted: the self-hosted runner group excludes public repositories.
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/n3o-docker-build-push-pgbouncer.yml
+++ b/.github/workflows/n3o-docker-build-push-pgbouncer.yml
@@ -5,11 +5,13 @@ name: 'docker-build-push-pgbouncer'
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   build-push-docker-image-job:
 
-    runs-on: n3o-github-runner
+    # GitHub-hosted: the self-hosted runner group excludes public repositories.
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/n3o-docker-build-push-postgres-upgrade.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres-upgrade.yml
@@ -11,7 +11,8 @@ on:
 jobs:
   build-push-docker-image-job:
 
-    runs-on: n3o-github-runner
+    # GitHub-hosted: the self-hosted runner group excludes public repositories.
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/n3o-docker-build-push-postgres.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres.yml
@@ -5,11 +5,13 @@ name: 'docker-build-push-postgres'
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   build-push-docker-image-job:
 
-    runs-on: n3o-github-runner
+    # GitHub-hosted: the self-hosted runner group excludes public repositories.
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/n3o-mirror-subtree.yml
+++ b/.github/workflows/n3o-mirror-subtree.yml
@@ -1,6 +1,6 @@
 # Reusable workflow that mirrors one subtree of a monorepo to an external client repo,
 # preserving history. A monorepo enables it with a thin per-client caller on push to main
-# (path-filtered to that client's subtree) — see n3oltd/sites/.github/workflows/mirror-*.yml.
+# (path-filtered to that client's subtree) — one caller per client.
 #
 # It splits the subtree out with full history (`git subtree split --prefix=<path>`) and
 # force-pushes the resulting commit to the client repo over SSH, using a per-client deploy
@@ -12,11 +12,11 @@ on:
   workflow_call:
     inputs:
       subtree-path:
-        description: 'Monorepo path of the subtree to mirror (e.g. src/site-mh)'
+        description: 'Monorepo path of the subtree to mirror'
         required: true
         type: string
       target-repo-url:
-        description: 'SSH URL of the client repo (e.g. ssh://git@github.com/muslimhands/website.git)'
+        description: 'SSH URL of the client repo'
         required: true
         type: string
       target-branch:


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

**Supersedes #173**, which added only the dispatch triggers.

This repository is public. The `n3o-github-runner` group has `allows_public_repositories = false`, so GitHub refuses to assign any job dispatched here to those runners — silently. The job queues against idle, online runners with no error and no annotation, which reads exactly like a capacity problem.

Confirmed by contrast rather than inference: while two builds dispatched here sat queued between 13:24 and 13:35, `n3oltd/backend` Main CI and `n3oltd/devops` Clean Up Old Packages were served by that same fleet at 13:27, 13:28 and 13:29. Both of those repositories are private.

The four image builds move to `ubuntu-latest`, which is where they belong regardless: they are `docker build` and push to ACR, needing no cluster access and nothing the fleet uniquely provides. Both preconditions checked — ACR is `publicNetworkAccess: Enabled` with `defaultAction: Allow` and no IP rules, and `ACR_USERNAME`/`ACR_PASSWORD` are org secrets with `visibility=all`.

**`docker-build-push.yml` deliberately keeps the self-hosted fleet.** A reusable workflow runs in its caller's context, every caller is a private repository, and it is not affected. Moving it would relocate every service image build in the estate for no reason.

`n3o-docker-build-push-postgres` and `-pgbouncer` also gain `workflow_dispatch`, so all four can be built on demand — nothing in this repository calls them, so previously there was no route to rebuild either at all.

## The privacy sweep

Prompted by the discovery that this repository is public. Across all 82 tracked files and 1,267 commits of history:

- **No credentials.** No tokens, private keys, storage account keys or SAS signatures, in current content or anywhere in history — a deleted secret is still public in a public repository, so history matters as much as `HEAD`.
- **No internal identifiers.** No private IP ranges, no subscription or tenant GUIDs, no internal hostnames.
- **One thing found and removed.** `n3o-mirror-subtree.yml` named a client's GitHub organisation and their subtree path in two input descriptions, and pointed at a private repository for an example caller. The workflow is generic without any of it.

`n3oltd.azurecr.io` appears throughout and stays — a registry hostname is not a credential, authentication is by secret, and a build repository cannot avoid naming its registry.

## Test plan

- [x] Every workflow in `.github/workflows` parses as YAML.
- [x] All four image workflows now declare `ubuntu-latest` and carry `workflow_dispatch`.
- [x] `docker-build-push.yml` unchanged and still on the fleet.
- [x] `muslimhands`, `site-mh` and `n3oltd/sites` no longer appear in `n3o-mirror-subtree.yml`.
- [x] Verified the runner group's `allows_public_repositories=false` and this repository's `visibility=public` are both current, and that private repositories are being served by the fleet concurrently.
- [ ] I will dispatch all four builds once this merges, and confirm each image reaches ACR.
