### PR TITLE
Keep the CA bundle in the postgres image

### DIFF
--- a/.github/workflows/n3o-mirror-subtree.yml
+++ b/.github/workflows/n3o-mirror-subtree.yml
@@ -1,6 +1,6 @@
 # Reusable workflow that mirrors one subtree of a monorepo to an external client repo,
 # preserving history. A monorepo enables it with a thin per-client caller on push to main
-# (path-filtered to that client's subtree) — one caller per client.
+# (path-filtered to that client's subtree) — see n3oltd/sites/.github/workflows/mirror-*.yml.
 #
 # It splits the subtree out with full history (`git subtree split --prefix=<path>`) and
 # force-pushes the resulting commit to the client repo over SSH, using a per-client deploy
@@ -12,11 +12,11 @@ on:
   workflow_call:
     inputs:
       subtree-path:
-        description: 'Monorepo path of the subtree to mirror'
+        description: 'Monorepo path of the subtree to mirror (e.g. src/site-mh)'
         required: true
         type: string
       target-repo-url:
-        description: 'SSH URL of the client repo'
+        description: 'SSH URL of the client repo (e.g. ssh://git@github.com/muslimhands/website.git)'
         required: true
         type: string
       target-branch:

--- a/docker/postgres
+++ b/docker/postgres
@@ -9,7 +9,8 @@ FROM postgres:17 AS base
 FROM base AS final
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends pgbackrest pgbadger procps \
+ # pgBackRest verifies the Azure Blob endpoint certificate.
+ && apt-get install -y --no-install-recommends ca-certificates pgbackrest pgbadger procps \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=0755 postgres-entrypoint.sh /usr/local/bin/postgres-entrypoint.sh


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

**This is a live breakage on the qa tenant and it is mine.** Backups there are failing now and will keep failing until this is merged, rebuilt and reapplied.

pgBackRest reaches Azure Blob over TLS and verifies the endpoint certificate against the system trust store. `ca-certificates` was never installed explicitly — it came in as a recommend of `wget`. #169 removed `wget` as dead weight and added `--no-install-recommends`, which took the trust store with it. Nothing in the build or the image start fails; only pgBackRest does, when it next tries to reach the repository:

```
ERROR: [095]: unable to load info file '/sqa/archive/n3o/archive.info'
CryptoError: unable to verify certificate presented by
'eu1backups.blob.core.windows.net:443': [20] unable to get local issuer certificate
```

The upgrade image is missing the bundle too and is **deliberately left alone** — it runs `initdb`, `pg_upgrade` and `pg_checksums` against a local data directory and opens no network connection. Adding a package it does not use would be cargo-culting the fix.

`n3o-pgbouncer` and `n3o-kubectl` both install `ca-certificates` explicitly already, so neither is affected.

## Test plan

- [x] Confirmed the old image `2026.7.22.69` has `ca-certificates 20250419` and `/etc/ssl/certs/ca-certificates.crt`; the new `2026.8.2.1` has neither.
- [x] Confirmed via `apt-cache rdepends` that `wget` was one of the packages pulling it in.
- [x] Checked all four images: `n3o-postgres` and `n3o-postgres-upgrade` were missing it, `n3o-pgbouncer` and `n3o-kubectl` were not.
- [x] Rebuilt with the fix: bundle restored at 224,449 bytes, pgBackRest 2.59.0 still present, and `cron`/`sudo`/`wget` still absent.
- [ ] Needs a rebuild and a reapply to qa before that tenant has a working backup again.