### PR TITLE
Let a tenant run without WAL archiving

### DIFF
--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -68,7 +68,7 @@ chmod 600 /etc/pgbackrest/pgbackrest.conf
 
 # Unit of tcp_keepalives_idle is seconds and idle_session_timeout is milliseconds
 exec docker-entrypoint.sh postgres \
-          -c archive_mode=on \
+          -c archive_mode="${POSTGRES_ARCHIVE_MODE:-on}" \
           -c archive_command="pgbackrest --stanza=n3o archive-push %p" \
           -c wal_level=replica \
           -c max_wal_senders=3 \


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

The other half of n3oltd/backend#709, and it has to land and be rebuilt first.

A tenant with no backup repository still archives. Every `archive-push` fails, and PostgreSQL will not recycle a WAL segment it has not archived, so `pg_wal` grows until the volume fills — a database that stops accepting writes because nothing was collecting the WAL it was told to produce.

`archive_mode` now follows `POSTGRES_ARCHIVE_MODE`, **defaulting to `on`** so a tenant that does not set the variable behaves exactly as before. Only the deploy template sets it, and only to `off`, and only for a pod declared without backups.

`archive_command` is left as it is: PostgreSQL ignores it when `archive_mode` is off, and making it conditional too would be two things to keep in step instead of one.

## Test plan

- [x] `bash -n` passes.
- [x] The default is `on`, so every existing tenant is unchanged — none of them sets the variable.
- [ ] Needs a rebuild of `n3o-postgres` before the template change in backend#709 has any effect.