### PR TITLE
Build the tenant image on PostgreSQL 18

### DIFF
--- a/docker/postgres
+++ b/docker/postgres
@@ -1,7 +1,7 @@
 ########################
 ### base
 ########################
-FROM postgres:17 AS base
+FROM postgres:18 AS base
 
 ########################
 ### final


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

Pass 1 is complete: all 36 tenants are on `n3o-postgres:2026.8.2.2`, SCRAM everywhere, no md5 password left in the estate, backups verified. Pass 2 moves each data directory from 17 to 18, and it needs an 18-based image for the tenant to come back up on.

**Publishing this image changes nothing on its own.** Every StatefulSet carries a pinned 17 tag and keeps it until Pass 2 patches that tenant individually.

The hazard to be aware of while the fleet is mixed: `ContainerRegistry.GetLatestContainerImage` resolves by newest manifest, so **running `n3o deploy postgres server` before every tenant has been upgraded would hand an 18 binary to a 17 data directory**, and those tenants would not start. No deploy until Pass 2 is finished on all 36, and then one deploy to reconcile the StatefulSets with what the CLI generates.

## Test plan

- [x] The upgrade path itself is already proven end to end on this Dockerfile's 17 and 18 forms — data byte-identical, statistics preserved, `pg_hba` carried across, rollback exercised.
- [ ] Verify the built image reports 18.4, carries the CA bundle and pgBackRest, and honours `POSTGRES_ARCHIVE_MODE`, before any tenant is patched to it.