### PR TITLE
Correct the data directory permissions before starting the old cluster

### DIFF
--- a/docker/assets/postgres-upgrade.sh
+++ b/docker/assets/postgres-upgrade.sh
@@ -33,8 +33,7 @@ version=$(cat "$PGDATA/PG_VERSION")
 [ -e "$RETAINED" ] && die "$RETAINED exists; a previous run left state behind"
 [ -e "$NEW" ] && die "$NEW exists; a previous run left state behind"
 
-# fsGroup adds group bits to the volume on mount, and PostgreSQL refuses to start on anything but
-# 0700 or 0750. The image entrypoint normally corrects this; nothing runs it here.
+# fsGroup adds group bits on mount; PostgreSQL refuses to start on them.
 chmod 0700 "$PGDATA"
 
 state=$(control 'Database cluster state')
@@ -56,7 +55,7 @@ if [ "$(control 'Data page checksum version')" = "0" ]; then
   $OLD_BIN/pg_checksums --enable -D "$PGDATA"
 fi
 
-# pg_upgrade writes its diagnosis inside the new cluster, so keep that before discarding it.
+# pg_upgrade writes its log inside the new cluster.
 salvage() {
   if [ -d "$NEW/pg_upgrade_output.d" ]; then
     rm -rf "${PGDATA}.upgrade-failed"

--- a/docker/assets/postgres-upgrade.sh
+++ b/docker/assets/postgres-upgrade.sh
@@ -33,6 +33,10 @@ version=$(cat "$PGDATA/PG_VERSION")
 [ -e "$RETAINED" ] && die "$RETAINED exists; a previous run left state behind"
 [ -e "$NEW" ] && die "$NEW exists; a previous run left state behind"
 
+# fsGroup adds group bits to the volume on mount, and PostgreSQL refuses to start on anything but
+# 0700 or 0750. The image entrypoint normally corrects this; nothing runs it here.
+chmod 0700 "$PGDATA"
+
 state=$(control 'Database cluster state')
 [ "$state" = "shut down" ] || die "cluster state is '$state'; pg_upgrade needs a clean shutdown"
 
@@ -52,7 +56,15 @@ if [ "$(control 'Data page checksum version')" = "0" ]; then
   $OLD_BIN/pg_checksums --enable -D "$PGDATA"
 fi
 
-trap 'rm -rf "$NEW"' ERR
+# pg_upgrade writes its diagnosis inside the new cluster, so keep that before discarding it.
+salvage() {
+  if [ -d "$NEW/pg_upgrade_output.d" ]; then
+    rm -rf "${PGDATA}.upgrade-failed"
+    mv "$NEW/pg_upgrade_output.d" "${PGDATA}.upgrade-failed" || true
+  fi
+  rm -rf "$NEW"
+}
+trap salvage ERR
 
 $NEW_BIN/initdb -D "$NEW" --locale="$PG_LOCALE" --encoding="$PG_ENCODING" -U "$POSTGRES_USER"
 


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3273

## Summary

The first real Pass 2 attempt failed on `prod` and this is why:

```
FATAL:  data directory "/var/lib/postgresql/data/postgres" has invalid permissions
DETAIL:  Permissions should be u=rwx (0700) or u=rwx,g=rx (0750).
```

`pg_upgrade` starts the old postmaster to inspect it, and PostgreSQL refuses a data directory carrying group bits. Kubernetes adds them: the StatefulSet sets `fsGroup: 999` with `fsGroupChangePolicy: Always`, so the volume is chmodded on every mount. Tenant pods are unaffected because the official `docker-entrypoint.sh` runs `chmod 00700 "$PGDATA"` on each start — I confirmed the running pods are 0700 and that the entrypoint contains that line. The upgrade job replaces that entrypoint, so nothing corrected it.

The script now does the same thing the entrypoint does, before it touches anything.

**Why my rehearsal missed it.** I built the cluster inside the container with `docker run`, where no `fsGroup` exists and the directory was already 0700. The defect only appears on a Kubernetes-mounted volume, which is the one place I had not tested.

### The failure also destroyed its own diagnosis

`pg_upgrade` writes `pg_upgrade_output.d` **inside the new cluster**, and the `ERR` trap deleted that directory — so the reason a run failed died with the run. It is now moved to `$PGDATA.upgrade-failed` before the scratch cluster is discarded. I had to reproduce the failure on a second tenant purely to read a log that should have survived the first.

## Test plan

- [x] Reproduced on a real tenant volume in the cluster, capturing the server log: the postmaster refuses to start, and the permission error is the sole cause.
- [x] Confirmed running tenant pods show `0700` and that `docker-entrypoint.sh` contains `chmod 00700`, so the fix mirrors established behaviour rather than inventing one.
- [x] `bash -n` passes.
- [x] Verified the reworked trap is total — no `&&` that can return non-zero from the handler — and still preserves the failing command's exit status (tested: exit 7 in, exit 7 out).
- [ ] Needs a rebuild of `n3o-postgres-upgrade`, then re-proving on a tenant before any further Pass 2.