### PR TITLE
Deploy a web app from a composite action, and publish by channel

### DIFF
--- a/.github/actions/n3o-webapp-deploy/action.yml
+++ b/.github/actions/n3o-webapp-deploy/action.yml
@@ -1,0 +1,83 @@
+name: 'N3O web app deploy'
+description: points an Azure Web App at a container image and restarts it
+
+inputs:
+  site-name:
+    description: web app name
+    required: true
+  resource-group:
+    description: Azure resource group
+    required: true
+  docker-image:
+    description: ACR repository, without registry or tag
+    required: true
+  image-tag:
+    description: tag to deploy
+    required: false
+    default: ''
+  app-settings:
+    description: additional app settings, space separated KEY=VALUE pairs
+    required: false
+    default: ''
+  website-port:
+    description: port the container listens on
+    required: false
+    default: '8080'
+  azure-credentials:
+    description: Azure service principal credentials
+    required: true
+  registry-username:
+    description: ACR username. Omit only where the app already carries the credentials as settings.
+    required: false
+    default: ''
+  registry-password:
+    description: ACR password
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: azure/login@v3
+      with:
+        creds: ${{ inputs.azure-credentials }}
+
+    - name: Deploy
+      shell: bash
+      env:
+        SITE: ${{ inputs.site-name }}
+        GROUP: ${{ inputs.resource-group }}
+        # Deploying the commit rather than a moving tag makes a rollback a
+        # re-point at the previous one.
+        IMAGE: n3oltd.azurecr.io/${{ inputs.docker-image }}:${{ inputs.image-tag || format('sha-{0}', github.sha) }}
+        REGISTRY_USERNAME: ${{ inputs.registry-username }}
+        REGISTRY_PASSWORD: ${{ inputs.registry-password }}
+        EXTRA_SETTINGS: ${{ inputs.app-settings }}
+        WEBSITE_PORT: ${{ inputs.website-port }}
+      run: |
+        set -euo pipefail
+
+        # A newly created app has no credentials of its own, and without them
+        # every step here still succeeds while the platform cannot pull.
+        credentials=()
+        if [ -n "$REGISTRY_USERNAME" ]; then
+          credentials=(--docker-registry-server-user "$REGISTRY_USERNAME"
+                       --docker-registry-server-password "$REGISTRY_PASSWORD")
+        fi
+
+        az webapp config container set \
+          --name "$SITE" --resource-group "$GROUP" \
+          --docker-custom-image-name "$IMAGE" \
+          --docker-registry-server-url https://n3oltd.azurecr.io \
+          "${credentials[@]}" \
+          --output none
+
+        # shellcheck disable=SC2086 — EXTRA_SETTINGS is a caller-supplied argument list.
+        az webapp config appsettings set \
+          --name "$SITE" --resource-group "$GROUP" \
+          --settings WEBSITES_PORT="$WEBSITE_PORT" $EXTRA_SETTINGS \
+          --output none
+
+        az webapp restart --name "$SITE" --resource-group "$GROUP" --output none
+
+        echo "Deployed $IMAGE to $SITE."

--- a/.github/actions/n3o-webapp-deploy/action.yml
+++ b/.github/actions/n3o-webapp-deploy/action.yml
@@ -27,13 +27,11 @@ inputs:
     description: Azure service principal credentials
     required: true
   registry-username:
-    description: ACR username. Omit only where the app already carries the credentials as settings.
-    required: false
-    default: ''
+    description: ACR username
+    required: true
   registry-password:
     description: ACR password
-    required: false
-    default: ''
+    required: true
 
 runs:
   using: 'composite'
@@ -57,19 +55,14 @@ runs:
       run: |
         set -euo pipefail
 
-        # A newly created app has no credentials of its own, and without them
-        # every step here still succeeds while the platform cannot pull.
-        credentials=()
-        if [ -n "$REGISTRY_USERNAME" ]; then
-          credentials=(--docker-registry-server-user "$REGISTRY_USERNAME"
-                       --docker-registry-server-password "$REGISTRY_PASSWORD")
-        fi
-
+        # Without these a newly created app runs every step here green and then
+        # cannot pull.
         az webapp config container set \
           --name "$SITE" --resource-group "$GROUP" \
           --docker-custom-image-name "$IMAGE" \
           --docker-registry-server-url https://n3oltd.azurecr.io \
-          "${credentials[@]}" \
+          --docker-registry-server-user "$REGISTRY_USERNAME" \
+          --docker-registry-server-password "$REGISTRY_PASSWORD" \
           --output none
 
         # shellcheck disable=SC2086 — EXTRA_SETTINGS is a caller-supplied argument list.

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -58,6 +58,12 @@ on:
         required: false
         default: wait
 
+      channel:
+        description: "release channel. Empty publishes :<calver> and :latest; a value publishes :<channel>-<calver> and :<channel>, leaving :latest to whichever pipeline deploys production."
+        type: string
+        required: false
+        default: ''
+
 env:
   GH_PAT: ${{ secrets.GH_PAT }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -116,12 +122,22 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: fetch dockerfile
+      - name: resolve dockerfile
         if: steps.check-existing.outputs.exists != 'true'
         shell: bash
+        env:
+          DOCKERFILE: ${{ inputs.dockerfile }}
         run: |
-          curl -fsSL -o "${{ inputs.dockerfile }}" \
-            "https://raw.githubusercontent.com/n3oltd/actions/main/docker/${{ inputs.dockerfile }}"
+          set -euo pipefail
+
+          # A repository committing its own Dockerfile keeps it under change
+          # detection; a bare name still resolves to the shared one here.
+          if [ -f "$DOCKERFILE" ]; then
+            echo "Using the Dockerfile committed at $DOCKERFILE"
+          else
+            curl -fsSL -o "$DOCKERFILE" \
+              "https://raw.githubusercontent.com/n3oltd/actions/main/docker/$DOCKERFILE"
+          fi
 
       - id: metadata
         name: metadata
@@ -129,9 +145,11 @@ jobs:
         run: |
           ACR_REPOSITORY=n3oltd.azurecr.io/${{ inputs.container-repository }}
           NOW=$(date -u +'%Y.%-m.%-d')
-          VERSION="$NOW.${{ github.run_number }}"
+          CHANNEL="${{ inputs.channel }}"
+          PREFIX="${CHANNEL:+${CHANNEL}-}"
+          VERSION="${PREFIX}${NOW}.${{ github.run_number }}"
           VERSIONTAG="${ACR_REPOSITORY}:${VERSION}"
-          LATESTTAG="${ACR_REPOSITORY}:latest"
+          LATESTTAG="${ACR_REPOSITORY}:${CHANNEL:-latest}"
           CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "version-tag=$VERSIONTAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/oauth-static-site-deploy.yml
+++ b/.github/workflows/oauth-static-site-deploy.yml
@@ -46,10 +46,10 @@ on:
         required: true
 
       registry-username:
-        required: false
+        required: true
 
       registry-password:
-        required: false
+        required: true
 
 jobs:
   deploy:

--- a/.github/workflows/oauth-static-site-deploy.yml
+++ b/.github/workflows/oauth-static-site-deploy.yml
@@ -1,6 +1,5 @@
-# Configures and restarts an Azure Web App running the OAuth2 Proxy in front of a static site.
-# Points the app at a Docker image and sets the OAuth2 Proxy app settings for Azure AD sign-in, then restarts the app.
-# Called to deploy or update an OAuth-protected static site on Azure.
+# Deploys an OAuth2-Proxy-fronted static site to an Azure Web App: points it at a
+# container image, sets the Azure AD sign-in settings, and restarts it.
 name: 'oauth-static-site-deploy'
 
 on:
@@ -46,43 +45,37 @@ on:
       cookie-secret:
         required: true
 
-jobs:
-  job1:
-    name: ubuntu-latest
+      registry-username:
+        required: false
 
+      registry-password:
+        required: false
+
+jobs:
+  deploy:
+    name: ${{ inputs.site-name }}
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7
 
-      - name: Azure Login
-        uses: azure/login@v3
+      - uses: n3oltd/actions/.github/actions/n3o-webapp-deploy@main
         with:
-          creds: ${{ secrets.azure-credentials }}
-
-      - name: Configure and restart webapp
-        run: |
-          az webapp config container set --name ${{ env.app_name }} --resource-group ${{ env.resource_group }} --docker-custom-image-name ${{ env.custom_image }} --docker-registry-server-url https://n3oltd.azurecr.io
-          az webapp config appsettings set --name ${{ env.app_name }} --resource-group ${{ env.resource_group }} --settings \
-            OAUTH2_PROXY_CLIENT_ID="${{ env.client_id }}" \
-            OAUTH2_PROXY_CLIENT_SECRET="${{ env.client_secret }}" \
-            OAUTH2_PROXY_COOKIE_SECRET="${{ env.cookie_secret }}" \
-            OAUTH2_PROXY_FOOTER="Copyright © N3O Ltd" \
-            OAUTH2_PROXY_CUSTOM_SIGN_IN_LOGO="https://n3oltd.blob.core.windows.net/public-assets/logos/logo.svg" \
-            OAUTH2_PROXY_EMAIL_DOMAINS="${{ env.email_domains }}" \
-            OAUTH2_PROXY_PROVIDER="azure" \
-            OAUTH2_PROXY_AZURE_TENANT_ID="${{ env.tenant_id }}" \
-            OAUTH2_PROXY_OIDC_ISSUER_URL="https://login.microsoftonline.com/${{ env.tenant_id }}/v2.0" \
-            OAUTH2_PROXY_REVERSE_PROXY="1" \
-            OAUTH2_PROXY_REAL_CLIENT_IP_HEADER="X-Forwarded-For" \
-            WEBSITES_PORT="8080"
-          az webapp restart --name ${{ env.app_name }} --resource-group ${{ env.resource_group }}
-        env:
-          app_name: "${{ inputs.site-name }}"
-          client_id: "${{ inputs.client-id }}"
-          client_secret: "${{ secrets.client-secret }}"
-          cookie_secret: "${{ secrets.cookie-secret }}"
-          custom_image: "n3oltd.azurecr.io/${{ inputs.docker-image }}:sha-${{ github.sha }}"
-          email_domains: "${{ inputs.email-domains }}"
-          resource_group: "${{ inputs.resource-group }}"
-          tenant_id: "${{ inputs.tenant-id }}"
+          site-name: ${{ inputs.site-name }}
+          resource-group: ${{ inputs.resource-group }}
+          docker-image: ${{ inputs.docker-image }}
+          azure-credentials: ${{ secrets.azure-credentials }}
+          registry-username: ${{ secrets.registry-username }}
+          registry-password: ${{ secrets.registry-password }}
+          app-settings: >-
+            OAUTH2_PROXY_CLIENT_ID="${{ inputs.client-id }}"
+            OAUTH2_PROXY_CLIENT_SECRET="${{ secrets.client-secret }}"
+            OAUTH2_PROXY_COOKIE_SECRET="${{ secrets.cookie-secret }}"
+            OAUTH2_PROXY_FOOTER="Copyright © N3O Ltd"
+            OAUTH2_PROXY_CUSTOM_SIGN_IN_LOGO="https://n3oltd.blob.core.windows.net/public-assets/logos/logo.svg"
+            OAUTH2_PROXY_EMAIL_DOMAINS="${{ inputs.email-domains }}"
+            OAUTH2_PROXY_PROVIDER="azure"
+            OAUTH2_PROXY_AZURE_TENANT_ID="${{ inputs.tenant-id }}"
+            OAUTH2_PROXY_OIDC_ISSUER_URL="https://login.microsoftonline.com/${{ inputs.tenant-id }}/v2.0"
+            OAUTH2_PROXY_REVERSE_PROXY="1"
+            OAUTH2_PROXY_REAL_CLIENT_IP_HEADER="X-Forwarded-For"


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Three changes the App Service frontends need, none of which alters an existing caller.

`n3o-webapp-deploy` is a new composite action holding the `az` calls that point a web app at a container image and restart it, so the deploy exists in one place rather than being copied per site. It sets the ACR pull credentials, which `oauth-static-site-deploy` never did — the sites that work today pull only because someone set those by hand at creation, which means a newly created app would run `container set`, `appsettings set` and `restart` all green and then serve an Application Error with nothing in the log to say why. The credentials are optional and applied only when supplied, so a caller that has not been updated behaves exactly as before.

A `channel` input on the build workflow separates release lineages inside one container repository. Unset — every caller today — a build publishes `:<calver>` and `:latest` as it always has. Set, it publishes `:<channel>-<calver>` and `:<channel>`, leaving `:latest` to whichever pipeline deploys production. Both still publish `:sha-<commit>`, which is what a deploy actually pins, so a release is an immutable image and a rollback is a re-point.

The dockerfile step now prefers one committed in the caller's checkout before falling back to fetching by name. A Dockerfile held in this repository is invisible to the change detection that decides what rebuilds, so a fix to it reaches nothing until an unrelated commit happens to trigger a build. A repository that would rather own its own can now do that without every other caller changing.

## Test plan

- [x] `action.yml` and both workflows parse as YAML
- [x] The deploy script parses as bash
- [x] Channel logic checked both ways: unset gives `2026.8.2.17` + `:latest`; `vnext` gives `vnext-2026.8.2.17` + `:vnext`
- [x] Credentials omitted when unsupplied, so the array expands to nothing and the `az` call matches today's
- [ ] Reviewer check: the next Storybook deploy still succeeds unchanged, proving the refactor is signature-compatible
