### PR TITLE
Bound a query pgBouncer believes is still running

### DIFF
--- a/docker/assets/pgbouncer-entrypoint.sh
+++ b/docker/assets/pgbouncer-entrypoint.sh
@@ -56,6 +56,7 @@ server_idle_timeout = ${POSTGRES_IDLE_SESSION_TIMEOUT}
 server_fast_close = 1
 client_idle_timeout = 300
 idle_transaction_timeout = 300
+query_timeout = 2100
 ignore_startup_parameters = extra_float_digits
 stats_period = 0
 verbose = 0


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3297

## Summary

pgBouncer sets `server->idle_tx` only when it handles a `ReadyForQuery`, which PostgreSQL
sends only in response to a Sync. A client that sends Parse, Bind and Execute and then stops
leaves PostgreSQL reporting the backend busy while pgBouncer believes a query is still in
flight, so `idle_transaction_timeout` cannot apply and neither can `server_idle_timeout`,
which needs the connection to be ready. With `query_timeout` unset, nothing reaps it.

Measured on a tenant: a session in that state survived a 420 second probe untouched, while
an otherwise identical session that had sent Sync was terminated at exactly 300 seconds.

Thirty five minutes sits just above the client's own command timeout, so the application
gives up first in the ordinary case and pgBouncer only acts where the application is not
waiting on anything.

## Test plan

- [x] `sh -n` on the entrypoint
- [ ] After rollout, confirm `SHOW CONFIG` reports `query_timeout = 2100` on a tenant
- [ ] Confirm a normal workload sees no new `query_timeout` entries in the pgBouncer log
