### PR TITLE
Quote the feed endpoints JSON so ENV keeps it a single token

### DIFF
--- a/docker/n3o-dotnet
+++ b/docker/n3o-dotnet
@@ -21,7 +21,7 @@ ARG CONFIGURATION
 WORKDIR /src
 
 ENV NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED=true
-ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS={\"endpointCredentials\": [{\"endpoint\":\"${FEED_URL}\", \"username\":\"n3oltd\", \"password\":\"${PAT}\"}]}
+ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS="{\"endpointCredentials\": [{\"endpoint\":\"${FEED_URL}\", \"username\":\"n3oltd\", \"password\":\"${PAT}\"}]}"
 ENV PROJECT=${PROJECT}
 ENV DLL=.dll
 


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Every container build in `n3oltd/backend` has failed since #180, all 58 of them, on
the Dockerfile's own parse:

```
n3o-dotnet:24
ERROR: failed to solve: Syntax error - can't find = in "[{\"endpoint\":\"${FEED_URL}\","
        Must be of the form: name=value
```

The two `ENV` forms are not interchangeable, which is what the conversion to `key=value`
ran into. `ENV k v` sets one variable and takes the rest of the line as the value, so
whitespace in it is not significant. `ENV k=v` sets any number of variables, so it must
split on whitespace first and then require `=` in every token. The `", "` separators
inside the endpoint credentials JSON had been inert under the first form; under the second
they became token boundaries, and the token starting `[{\"endpoint\":` has no `=`.

Quoting the value makes it one token again, and keeps it one if the JSON is ever
reformatted — removing today's two spaces would fix the parse but leave the next person to
pretty-print it in the same trap.

Nothing else in `docker/` is affected: this is the only file setting
`VSS_NUGET_EXTERNAL_FEED_ENDPOINTS`, and the only other `key=value` values carrying spaces
are the multi-line continuations in `n3o-react` and `n3o-vite`, which are already
one pair per line.

Worth noting for what caught it and what did not. `docker build --check` reports this
class, but no workflow in this repo builds anything under `docker/`, so the file ships
untested and consumers `curl` it from `main` unpinned. The first execution of the line was
a consumer's nightly, at fleet scale, hours after merge. A smoke job running
`docker build --check` over `docker/*` on PRs would close that gap in seconds; I have left
it out of this PR to keep the outage fix to one line.

## Test plan

- [x] `docker/n3o-dotnet` is the only Dockerfile here setting `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS`
- [x] No other `ENV`/`ARG` `key=value` line in `docker/` has unquoted whitespace in its value
- [x] Diff is one line; UTF-8 BOM and LF endings unchanged
- [ ] **Not built.** No Docker on the machine this was written on, so the fix is reasoned
      from the parse grammar, not observed. Before this is relied on, one real build should
      confirm both halves — that line 24 parses, and that the resolved variable is still
      valid JSON that authenticates against the feed. A consumer-side check does that
      without waiting for a nightly, since `resolve dockerfile` prefers a Dockerfile
      committed in the consumer repo: commit this file as `n3o-dotnet` at the root of a
      throwaway `backend` branch, then
      `gh workflow run build-containers.yml --ref <branch> -f services=svc-be-activities -f fast=true`.
      A restore that 401s past line 24 would mean the outer quotes are being kept in the
      value, in which case the fix is to drop them and delete the two interior spaces.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
