### PR TITLE
Add the SQL Server image

### DIFF
--- a/.github/workflows/n3o-docker-build-push-mssql.yml
+++ b/.github/workflows/n3o-docker-build-push-mssql.yml
@@ -1,0 +1,56 @@
+# Builds and pushes the N3O SQL Server Docker image to ACR with date and
+# latest tags, fetching the Dockerfile from the actions repo. Takes no
+# inputs.
+name: 'docker-build-push-mssql'
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-push-docker-image-job:
+
+    # GitHub-hosted: the self-hosted runner group excludes public repositories.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - id: buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: acr login
+        uses: docker/login-action@v4
+        with:
+          registry: n3oltd.azurecr.io
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: fetch dockerfile
+        shell: bash
+        run: |
+          curl -fsSL -o mssql \
+            https://raw.githubusercontent.com/n3oltd/actions/main/docker/mssql
+
+      - id: meta-mssql
+        name: prepare mssql
+        run: |
+          DOCKER_IMAGE_NAME=n3o-mssql
+          DOCKER_IMAGE=n3oltd.azurecr.io/$DOCKER_IMAGE_NAME
+          NOW=$(date -u +'%Y.%-m.%-d')
+          VERSION="$NOW.${{ github.run_number }}"
+          VERSIONTAG="${DOCKER_IMAGE}:${VERSION}"
+          LATESTTAG="${DOCKER_IMAGE}:latest"
+          echo "versiontag=$VERSIONTAG" >> $GITHUB_OUTPUT
+          echo "latesttag=$LATESTTAG" >> $GITHUB_OUTPUT
+
+      - name: build and push mssql
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          target: final
+          file: mssql
+          pull: true
+          push: true
+          tags: ${{ steps.meta-mssql.outputs.versiontag }} , ${{ steps.meta-mssql.outputs.latesttag }}

--- a/docker/mssql
+++ b/docker/mssql
@@ -1,0 +1,16 @@
+########################
+### base
+########################
+FROM mcr.microsoft.com/mssql/server:2025-latest AS base
+
+########################
+### final
+########################
+FROM base AS final
+
+# sqlcmd and bcp ship in the base image but not on PATH.
+ENV PATH="/opt/mssql-tools18/bin:${PATH}"
+
+USER mssql
+
+EXPOSE 1433


### PR DESCRIPTION
no-work-issue

## Summary

Adds the SQL Server 2025 image used by the `eu1` database tier, following the same
arrangement as the Postgres image: a Dockerfile at `docker/mssql`, a reusable build/push
workflow beside `n3o-docker-build-push-postgres.yml`, and a thin caller in `n3oltd/devops`.

One image serves both the production and QA instances. The edition is a runtime choice
through `MSSQL_PID`, not a build-time one, so a QA pilot built on a separate image would
rehearse different binaries and prove nothing about production.

The derivation is thin because there was nothing to add. Every database on the tier was
queried for full-text catalogs and indexes and none has any, so `mssql-server-fts` would
serve nothing; and backups run `BACKUP DATABASE ... TO URL` through a SQL CREDENTIAL, so
SQL Server does that work itself using the `ca-certificates` already in the base image. What
the derivation is actually for is the tag: `2025-latest` moves, and a cumulative update needs
a reviewable bump with a previous tag to roll back to.

`sqlcmd` and `bcp` ship in the base image but not on `PATH`, so the probes, the preStop hook
and the backup jobs would each have to carry the absolute path.

## Test plan

- [x] Built and pushed from this exact file via ACR Tasks — `n3o-mssql:2026.8.4.1`, digest `sha256:19c2dea9`
- [x] Both instances started from it and reported the expected editions: `Enterprise Edition: Core-based Licensing` and `Enterprise Developer Edition`, SQL Server 2025 (17.0.4065.4)
- [x] Readiness, liveness and startup probes pass, which exercises `sqlcmd` resolving on `PATH`
- [x] Backup CronJobs run against the pod and write encrypted, compressed backups to blob storage