### PR TITLE
Hold the repeated build and auth steps in one action each

### DIFF
--- a/.github/actions/n3o-acr-login/action.yml
+++ b/.github/actions/n3o-acr-login/action.yml
@@ -1,0 +1,32 @@
+name: n3o acr login
+description: The one place docker/setup-buildx-action and docker/login-action are pinned. Starts a buildx builder and signs in to the N3O container registry.
+
+inputs:
+  username:
+    description: Registry username.
+    required: true
+  password:
+    description: Registry password.
+    required: true
+  registry:
+    description: Container registry to sign in to.
+    required: false
+    default: n3oltd.azurecr.io
+
+outputs:
+  builder:
+    description: The buildx builder to pass to docker/build-push-action.
+    value: ${{ steps.buildx.outputs.name }}
+
+runs:
+  using: "composite"
+  steps:
+    # Bootstraps the buildx builder against the DinD daemon; not a redundant install.
+    - id: buildx
+      uses: docker/setup-buildx-action@v4
+
+    - uses: docker/login-action@v4
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}

--- a/.github/actions/n3o-app-token/action.yml
+++ b/.github/actions/n3o-app-token/action.yml
@@ -1,0 +1,29 @@
+name: n3o app token
+description: The one place actions/create-github-app-token is pinned. Mints an installation token for an N3O GitHub App.
+
+inputs:
+  app-id:
+    description: GitHub App id.
+    required: true
+  private-key:
+    description: GitHub App private key.
+    required: true
+  owner:
+    description: Owner/org the minted token is scoped to.
+    required: false
+    default: n3oltd
+
+outputs:
+  token:
+    description: The minted App installation token.
+    value: ${{ steps.app-token.outputs.token }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}

--- a/.github/actions/n3o-dockerfile-fetch/action.yml
+++ b/.github/actions/n3o-dockerfile-fetch/action.yml
@@ -1,0 +1,43 @@
+name: n3o dockerfile fetch
+description: >-
+  The one place the shared Dockerfile catalogue is addressed. Fetches a
+  Dockerfile from this repository's docker/ directory, along with any companion
+  assets it copies.
+
+inputs:
+  dockerfile:
+    description: Catalogue Dockerfile name, written to this path in the workspace.
+    required: true
+  assets:
+    description: Newline-separated docker/assets names to fetch alongside it, each written to the workspace root.
+    required: false
+    default: ''
+  prefer-local:
+    description: Use a Dockerfile already committed at this path instead of fetching. A repository committing its own keeps it under change detection; a bare name still resolves to the shared one.
+    required: false
+    default: 'false'
+
+runs:
+  using: "composite"
+  steps:
+    # Fetched over HTTP: the calling workflow checks out its own repository, not this one.
+    - shell: bash
+      env:
+        DOCKERFILE: ${{ inputs.dockerfile }}
+        ASSETS: ${{ inputs.assets }}
+        PREFER_LOCAL: ${{ inputs.prefer-local }}
+      run: |
+        set -euo pipefail
+        catalogue=https://raw.githubusercontent.com/n3oltd/actions/main/docker
+
+        if [ "$PREFER_LOCAL" = "true" ] && [ -f "$DOCKERFILE" ]; then
+          echo "Using the Dockerfile committed at $DOCKERFILE"
+        else
+          curl -fsSL -o "$DOCKERFILE" "$catalogue/$DOCKERFILE"
+        fi
+
+        while IFS= read -r asset; do
+          if [ -n "$asset" ]; then
+            curl -fsSL -o "$asset" "$catalogue/assets/$asset"
+          fi
+        done <<< "$ASSETS"

--- a/.github/actions/n3o-git-identity/action.yml
+++ b/.github/actions/n3o-git-identity/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: mint app token
       id: app-token
       if: inputs.app-id != ''
-      uses: actions/create-github-app-token@v3
+      uses: n3oltd/actions/.github/actions/n3o-app-token@main
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}

--- a/.github/actions/n3o-image-tags/action.yml
+++ b/.github/actions/n3o-image-tags/action.yml
@@ -1,0 +1,57 @@
+name: n3o image tags
+description: >-
+  The one place the N3O container image version scheme lives. Computes a calver
+  version from the date and the run number, the tags a build pushes, and the
+  build timestamp for the OCI labels.
+
+inputs:
+  repository:
+    description: Registry repository the image is pushed to, without the registry host.
+    required: true
+  registry:
+    description: Container registry the image is pushed to.
+    required: false
+    default: n3oltd.azurecr.io
+  channel:
+    description: Release channel. Empty publishes :<calver> and :latest; a value publishes :<channel>-<calver> and :<channel>, leaving :latest to whichever pipeline deploys production.
+    required: false
+    default: ''
+
+outputs:
+  version:
+    description: The calver version, channel-prefixed when a channel is set.
+    value: ${{ steps.tags.outputs.version }}
+  version-tag:
+    description: Fully qualified tag for this version.
+    value: ${{ steps.tags.outputs.version-tag }}
+  latest-tag:
+    description: Fully qualified moving tag for the channel.
+    value: ${{ steps.tags.outputs.latest-tag }}
+  sha-tag:
+    description: Fully qualified commit tag, which is what a deploy pins.
+    value: ${{ steps.tags.outputs.sha-tag }}
+  created:
+    description: RFC 3339 build timestamp for org.opencontainers.image.created.
+    value: ${{ steps.tags.outputs.created }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: tags
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.registry }}/${{ inputs.repository }}
+        CHANNEL: ${{ inputs.channel }}
+        RUN_NUMBER: ${{ github.run_number }}
+        SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+        NOW=$(date -u +'%Y.%-m.%-d')
+        VERSION="${CHANNEL:+${CHANNEL}-}${NOW}.${RUN_NUMBER}"
+        {
+          echo "version=$VERSION"
+          echo "version-tag=${IMAGE}:${VERSION}"
+          echo "latest-tag=${IMAGE}:${CHANNEL:-latest}"
+          echo "sha-tag=${IMAGE}:sha-${SHA}"
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -57,38 +57,28 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - id: buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to ACR
-        uses: docker/login-action@v4
+      - id: acr
+        name: Login to ACR
+        uses: n3oltd/actions/.github/actions/n3o-acr-login@main
         with:
-          registry: n3oltd.azurecr.io
           username: ${{ secrets.acr-username }}
           password: ${{ secrets.acr-password }}
 
       - name: Fetch Dockerfile
-        shell: bash
-        run: |
-          curl -fsSL -o "${{ inputs.dockerfile }}" \
-            "https://raw.githubusercontent.com/n3oltd/actions/main/docker/${{ inputs.dockerfile }}"
+        uses: n3oltd/actions/.github/actions/n3o-dockerfile-fetch@main
+        with:
+          dockerfile: ${{ inputs.dockerfile }}
 
       - id: meta
         name: Set tags
-        run: |
-          ACR_REPOSITORY=n3oltd.azurecr.io/${{ inputs.container-repository }}
-          NOW=$(date -u +'%Y.%-m.%-d')
-          VERSION="$NOW.${{ github.run_number }}"
-          VERSIONTAG="${ACR_REPOSITORY}:${VERSION}"
-          LATESTTAG="${ACR_REPOSITORY}:latest"
-          TAGS="${VERSIONTAG},${LATESTTAG}"
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        uses: n3oltd/actions/.github/actions/n3o-image-tags@main
+        with:
+          repository: ${{ inputs.container-repository }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
-          builder: ${{ steps.buildx.outputs.name }}
+          builder: ${{ steps.acr.outputs.builder }}
           context: ./${{ inputs.working-directory }}
           target: final
           file: ${{ inputs.dockerfile }}
@@ -97,7 +87,9 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
             SOURCE_REVISION_ID=${{ github.sha }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.version-tag }}
+            ${{ steps.meta.outputs.latest-tag }}
 
       - name: sentry release
         if: inputs.sentry-project != ''

--- a/.github/workflows/n3o-auto-triage-issues.yml
+++ b/.github/workflows/n3o-auto-triage-issues.yml
@@ -19,11 +19,10 @@ jobs:
     steps:
       - name: app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: n3oltd/actions/.github/actions/n3o-app-token@main
         with:
           app-id: ${{ secrets.N3O_APP_ID }}
           private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
-          owner: n3oltd
 
       - name: apply triage label
         env:

--- a/.github/workflows/n3o-docker-build-push-kubectl.yml
+++ b/.github/workflows/n3o-docker-build-push-kubectl.yml
@@ -15,40 +15,30 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - id: buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: acr login
-        uses: docker/login-action@v4
+      - id: acr
+        name: acr login
+        uses: n3oltd/actions/.github/actions/n3o-acr-login@main
         with:
-          registry: n3oltd.azurecr.io
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
       - name: fetch dockerfile
-        shell: bash
-        run: |
-          curl -fsSL -o kubectl \
-            https://raw.githubusercontent.com/n3oltd/actions/main/docker/kubectl
+        uses: n3oltd/actions/.github/actions/n3o-dockerfile-fetch@main
+        with:
+          dockerfile: kubectl
 
-      - id: meta-kubectl
+      - id: meta
         name: prepare kubectl
-        run: |
-          DOCKER_IMAGE_NAME=n3o-kubectl
-          DOCKER_IMAGE=n3oltd.azurecr.io/$DOCKER_IMAGE_NAME
-          NOW=$(date -u +'%Y.%-m.%-d')
-          VERSION="$NOW.${{ github.run_number }}"
-          VERSIONTAG="${DOCKER_IMAGE}:${VERSION}"
-          LATESTTAG="${DOCKER_IMAGE}:latest"
-          echo "versiontag=$VERSIONTAG" >> $GITHUB_OUTPUT
-          echo "latesttag=$LATESTTAG" >> $GITHUB_OUTPUT
+        uses: n3oltd/actions/.github/actions/n3o-image-tags@main
+        with:
+          repository: n3o-kubectl
 
       - name: build and push kubectl
         uses: docker/build-push-action@v7
         with:
-          builder: ${{ steps.buildx.outputs.name }}
+          builder: ${{ steps.acr.outputs.builder }}
           context: .
           target: final
           file: kubectl
           push: true
-          tags: ${{ steps.meta-kubectl.outputs.versiontag }} , ${{ steps.meta-kubectl.outputs.latesttag }}
+          tags: ${{ steps.meta.outputs.version-tag }} , ${{ steps.meta.outputs.latest-tag }}

--- a/.github/workflows/n3o-docker-build-push-mssql.yml
+++ b/.github/workflows/n3o-docker-build-push-mssql.yml
@@ -16,41 +16,31 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - id: buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: acr login
-        uses: docker/login-action@v4
+      - id: acr
+        name: acr login
+        uses: n3oltd/actions/.github/actions/n3o-acr-login@main
         with:
-          registry: n3oltd.azurecr.io
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
       - name: fetch dockerfile
-        shell: bash
-        run: |
-          curl -fsSL -o mssql \
-            https://raw.githubusercontent.com/n3oltd/actions/main/docker/mssql
+        uses: n3oltd/actions/.github/actions/n3o-dockerfile-fetch@main
+        with:
+          dockerfile: mssql
 
-      - id: meta-mssql
+      - id: meta
         name: prepare mssql
-        run: |
-          DOCKER_IMAGE_NAME=n3o-mssql
-          DOCKER_IMAGE=n3oltd.azurecr.io/$DOCKER_IMAGE_NAME
-          NOW=$(date -u +'%Y.%-m.%-d')
-          VERSION="$NOW.${{ github.run_number }}"
-          VERSIONTAG="${DOCKER_IMAGE}:${VERSION}"
-          LATESTTAG="${DOCKER_IMAGE}:latest"
-          echo "versiontag=$VERSIONTAG" >> $GITHUB_OUTPUT
-          echo "latesttag=$LATESTTAG" >> $GITHUB_OUTPUT
+        uses: n3oltd/actions/.github/actions/n3o-image-tags@main
+        with:
+          repository: n3o-mssql
 
       - name: build and push mssql
         uses: docker/build-push-action@v7
         with:
-          builder: ${{ steps.buildx.outputs.name }}
+          builder: ${{ steps.acr.outputs.builder }}
           context: .
           target: final
           file: mssql
           pull: true
           push: true
-          tags: ${{ steps.meta-mssql.outputs.versiontag }} , ${{ steps.meta-mssql.outputs.latesttag }}
+          tags: ${{ steps.meta.outputs.version-tag }} , ${{ steps.meta.outputs.latest-tag }}

--- a/.github/workflows/n3o-docker-build-push-pgbouncer.yml
+++ b/.github/workflows/n3o-docker-build-push-pgbouncer.yml
@@ -15,43 +15,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-                            
-      - id: buildx
-        uses: docker/setup-buildx-action@v4
 
-      - name: acr login
-        uses: docker/login-action@v4
+      - id: acr
+        name: acr login
+        uses: n3oltd/actions/.github/actions/n3o-acr-login@main
         with:
-          registry: n3oltd.azurecr.io
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
       - name: fetch dockerfile and entrypoint
-        shell: bash
-        run: |
-          curl -fsSL -o pgbouncer \
-            https://raw.githubusercontent.com/n3oltd/actions/main/docker/pgbouncer
-          curl -fsSL -o pgbouncer-entrypoint.sh \
-            https://raw.githubusercontent.com/n3oltd/actions/main/docker/assets/pgbouncer-entrypoint.sh
+        uses: n3oltd/actions/.github/actions/n3o-dockerfile-fetch@main
+        with:
+          dockerfile: pgbouncer
+          assets: pgbouncer-entrypoint.sh
 
-      - id: meta-pgbouncer
+      - id: meta
         name: prepare pgbouncer
-        run: |
-          DOCKER_IMAGE_NAME=n3o-pgbouncer
-          DOCKER_IMAGE=n3oltd.azurecr.io/$DOCKER_IMAGE_NAME
-          NOW=$(date -u +'%Y.%-m.%-d')
-          VERSION="$NOW.${{ github.run_number }}"       
-          VERSIONTAG="${DOCKER_IMAGE}:${VERSION}"
-          LATESTTAG="${DOCKER_IMAGE}:latest"
-          echo "versiontag=$VERSIONTAG" >> $GITHUB_OUTPUT
-          echo "latesttag=$LATESTTAG" >> $GITHUB_OUTPUT
+        uses: n3oltd/actions/.github/actions/n3o-image-tags@main
+        with:
+          repository: n3o-pgbouncer
 
       - name: build and push pgbouncer
         uses: docker/build-push-action@v7
         with:
-          builder: ${{ steps.buildx.outputs.name }}
+          builder: ${{ steps.acr.outputs.builder }}
           context: .
           target: final
           file: pgbouncer
           push: true
-          tags: ${{ steps.meta-pgbouncer.outputs.versiontag }} , ${{ steps.meta-pgbouncer.outputs.latesttag }}
+          tags: ${{ steps.meta.outputs.version-tag }} , ${{ steps.meta.outputs.latest-tag }}

--- a/.github/workflows/n3o-docker-build-push-postgres.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres.yml
@@ -15,43 +15,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-                            
-      - id: buildx
-        uses: docker/setup-buildx-action@v4
 
-      - name: acr login
-        uses: docker/login-action@v4
+      - id: acr
+        name: acr login
+        uses: n3oltd/actions/.github/actions/n3o-acr-login@main
         with:
-          registry: n3oltd.azurecr.io
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
       - name: fetch dockerfile and entrypoint
-        shell: bash
-        run: |
-          curl -fsSL -o postgres \
-            https://raw.githubusercontent.com/n3oltd/actions/main/docker/postgres
-          curl -fsSL -o postgres-entrypoint.sh \
-            https://raw.githubusercontent.com/n3oltd/actions/main/docker/assets/postgres-entrypoint.sh
+        uses: n3oltd/actions/.github/actions/n3o-dockerfile-fetch@main
+        with:
+          dockerfile: postgres
+          assets: postgres-entrypoint.sh
 
-      - id: meta-postgres
+      - id: meta
         name: prepare postgres
-        run: |
-          DOCKER_IMAGE_NAME=n3o-postgres
-          DOCKER_IMAGE=n3oltd.azurecr.io/$DOCKER_IMAGE_NAME
-          NOW=$(date -u +'%Y.%-m.%-d')
-          VERSION="$NOW.${{ github.run_number }}"       
-          VERSIONTAG="${DOCKER_IMAGE}:${VERSION}"
-          LATESTTAG="${DOCKER_IMAGE}:latest"
-          echo "versiontag=$VERSIONTAG" >> $GITHUB_OUTPUT
-          echo "latesttag=$LATESTTAG" >> $GITHUB_OUTPUT
+        uses: n3oltd/actions/.github/actions/n3o-image-tags@main
+        with:
+          repository: n3o-postgres
 
       - name: build and push postgres
         uses: docker/build-push-action@v7
         with:
-          builder: ${{ steps.buildx.outputs.name }}
+          builder: ${{ steps.acr.outputs.builder }}
           context: .
           target: final
           file: postgres
           push: true
-          tags: ${{ steps.meta-postgres.outputs.versiontag }} , ${{ steps.meta-postgres.outputs.latesttag }}
+          tags: ${{ steps.meta.outputs.version-tag }} , ${{ steps.meta.outputs.latest-tag }}

--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -99,14 +99,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Bootstraps the buildx builder against the DinD daemon; not a redundant install.
-      - id: buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: acr login
-        uses: docker/login-action@v4
+      - id: acr
+        name: acr login
+        uses: n3oltd/actions/.github/actions/n3o-acr-login@main
         with:
-          registry: n3oltd.azurecr.io
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
@@ -124,37 +120,18 @@ jobs:
 
       - name: resolve dockerfile
         if: steps.check-existing.outputs.exists != 'true'
-        shell: bash
-        env:
-          DOCKERFILE: ${{ inputs.dockerfile }}
-        run: |
-          set -euo pipefail
-
-          # A repository committing its own Dockerfile keeps it under change
-          # detection; a bare name still resolves to the shared one here.
-          if [ -f "$DOCKERFILE" ]; then
-            echo "Using the Dockerfile committed at $DOCKERFILE"
-          else
-            curl -fsSL -o "$DOCKERFILE" \
-              "https://raw.githubusercontent.com/n3oltd/actions/main/docker/$DOCKERFILE"
-          fi
+        uses: n3oltd/actions/.github/actions/n3o-dockerfile-fetch@main
+        with:
+          dockerfile: ${{ inputs.dockerfile }}
+          prefer-local: true
 
       - id: metadata
         name: metadata
         if: steps.check-existing.outputs.exists != 'true'
-        run: |
-          ACR_REPOSITORY=n3oltd.azurecr.io/${{ inputs.container-repository }}
-          NOW=$(date -u +'%Y.%-m.%-d')
-          CHANNEL="${{ inputs.channel }}"
-          PREFIX="${CHANNEL:+${CHANNEL}-}"
-          VERSION="${PREFIX}${NOW}.${{ github.run_number }}"
-          VERSIONTAG="${ACR_REPOSITORY}:${VERSION}"
-          LATESTTAG="${ACR_REPOSITORY}:${CHANNEL:-latest}"
-          CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "version-tag=$VERSIONTAG" >> $GITHUB_OUTPUT
-          echo "latest-tag=$LATESTTAG" >> $GITHUB_OUTPUT
-          echo "created=$CREATED" >> $GITHUB_OUTPUT
+        uses: n3oltd/actions/.github/actions/n3o-image-tags@main
+        with:
+          repository: ${{ inputs.container-repository }}
+          channel: ${{ inputs.channel }}
 
       - id: build-args
         name: prepare build args
@@ -212,7 +189,7 @@ jobs:
         continue-on-error: true
         uses: docker/build-push-action@v7
         with:
-          builder: ${{ steps.buildx.outputs.name }}
+          builder: ${{ steps.acr.outputs.builder }}
           context: ${{ inputs.context }}
           target: final
           file: ${{ inputs.dockerfile }}
@@ -225,7 +202,7 @@ jobs:
           tags: |
             ${{ steps.metadata.outputs.version-tag }}
             ${{ steps.metadata.outputs.latest-tag }}
-            n3oltd.azurecr.io/${{ inputs.container-repository }}:sha-${{ github.sha }}
+            ${{ steps.metadata.outputs.sha-tag }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
@@ -235,7 +212,7 @@ jobs:
         if: steps.check-existing.outputs.exists != 'true' && steps.build.outcome == 'failure'
         uses: docker/build-push-action@v7
         with:
-          builder: ${{ steps.buildx.outputs.name }}
+          builder: ${{ steps.acr.outputs.builder }}
           context: ${{ inputs.context }}
           target: final
           file: ${{ inputs.dockerfile }}
@@ -248,7 +225,7 @@ jobs:
           tags: |
             ${{ steps.metadata.outputs.version-tag }}
             ${{ steps.metadata.outputs.latest-tag }}
-            n3oltd.azurecr.io/${{ inputs.container-repository }}:sha-${{ github.sha }}
+            ${{ steps.metadata.outputs.sha-tag }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
@@ -258,7 +235,7 @@ jobs:
         if: steps.check-existing.outputs.exists != 'true' && inputs.sentry-project != '' && inputs.sentry-extract-sourcemaps
         uses: docker/build-push-action@v7
         with:
-          builder: ${{ steps.buildx.outputs.name }}
+          builder: ${{ steps.acr.outputs.builder }}
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           target: sourcemaps

--- a/.github/workflows/n3o-dotnet-generate-clients.yml
+++ b/.github/workflows/n3o-dotnet-generate-clients.yml
@@ -32,11 +32,10 @@ jobs:
     steps:
       - name: app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: n3oltd/actions/.github/actions/n3o-app-token@main
         with:
           app-id: ${{ secrets.N3O_APP_ID }}
           private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
-          owner: n3oltd
 
       - name: checkout
         uses: actions/checkout@v7

--- a/.github/workflows/n3o-work-dispatch.yml
+++ b/.github/workflows/n3o-work-dispatch.yml
@@ -18,11 +18,10 @@ jobs:
     steps:
       - name: app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: n3oltd/actions/.github/actions/n3o-app-token@main
         with:
           app-id: ${{ secrets.N3O_APP_ID }}
           private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
-          owner: n3oltd
 
       - name: setup dotnet + n3o cli
         uses: n3oltd/actions/.github/actions/n3o-dotnet-cli-setup@main
@@ -124,11 +123,10 @@ jobs:
       - name: app token
         if: steps.gate.outputs.skip != 'true'
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: n3oltd/actions/.github/actions/n3o-app-token@main
         with:
           app-id: ${{ secrets.N3O_APP_ID }}
           private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
-          owner: n3oltd
 
       - name: setup dotnet + n3o cli
         if: steps.gate.outputs.skip != 'true'
@@ -166,11 +164,10 @@ jobs:
     steps:
       - name: app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: n3oltd/actions/.github/actions/n3o-app-token@main
         with:
           app-id: ${{ secrets.N3O_APP_ID }}
           private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
-          owner: n3oltd
 
       - name: setup dotnet + n3o cli
         uses: n3oltd/actions/.github/actions/n3o-dotnet-cli-setup@main


### PR DESCRIPTION
no-work-issue

## Summary

Four step sequences were copied across the workflows in this repository and in n3oltd/devops, so a version bump or a registry change had to be made at every call site — and usually was not. The buildx and registry-login actions sit at v3 in one caller and v4 in the others; `create-github-app-token` sits at v2 in devops and v3 here.

Four composite actions now hold one decision each:

| Action | Holds | Call sites |
| --- | --- | --- |
| `n3o-acr-login` | the buildx bootstrap, the registry host and the sign-in; returns the builder | 10 |
| `n3o-image-tags` | the calver scheme — date, run number, optional channel prefix — and the tags derived from it | 10 |
| `n3o-dockerfile-fetch` | the address of the shared Dockerfile catalogue | 6 |
| `n3o-app-token` | the App token mint and the `n3oltd` scoping every caller uses | 9 |

The workflows here consume all four rather than only serving them, so each action has a caller in this repository and the drift cannot reappear from this side. `n3o-git-identity` mints through `n3o-app-token` for the same reason.

`docker/build-push-action` is deliberately left at each call site. It is invoked twelve times across the two repositories and the invocations differ in target, pull, no-cache, build arguments, build secrets, labels, local output and retry — one job calls it three times, no two alike. A wrapper serving all of that would take more inputs than the action's own surface at these sites, and every future option would need the wrapper changed before any caller could reach it.

No workflow changes what it does. The one substantive difference is that the tag computation reads `date -u` everywhere; four call sites read local time, and on a runner that sets no timezone the two agree.

## Merge order

This lands before n3oltd/devops#381, which calls these actions at `@main`.

The `work-dispatch` check on this PR is expected to fail: it runs this branch's copy of `n3o-work-dispatch.yml`, which resolves `n3o-app-token@main` — an action that does not exist on `main` until this merges. Pinning a sibling action at `@main` is the existing convention here (`n3o-dotnet-cli-setup` does the same), and a relative `./` reference is not an option: it resolves against the caller's checkout, and the step runs before any checkout.

## Test plan

- [x] Every changed file parses as YAML.
- [x] Every `steps.<id>.outputs.<name>` reference in both repositories resolves to a declared output, and every call site passes only declared inputs and omits no required one (scripted cross-check over all 28 composite actions).
- [x] The `n3o-image-tags` shell reproduces the originals for both the empty and the set channel: `2026.8.4.42` / `:latest`, and `qa-2026.8.4.7` / `:qa`.
- [x] The `n3o-dockerfile-fetch` shell reproduces the originals for no assets, one asset, two assets, and `prefer-local` with the file present and absent.
- [ ] A build of each image after merge, since none of these workflows runs on a pull request.
