### PR TITLE
Add pg_repack to the postgres image

### DIFF
--- a/docker/postgres
+++ b/docker/postgres
@@ -10,7 +10,8 @@ FROM base AS final
 
 RUN apt-get update \
  # pgBackRest verifies the Azure Blob endpoint certificate.
- && apt-get install -y --no-install-recommends ca-certificates pgbackrest pgbadger procps \
+ # postgresql-N-repack is pinned to the major version and must be bumped alongside the base.
+ && apt-get install -y --no-install-recommends ca-certificates pgbackrest pgbadger procps postgresql-18-repack \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=0755 postgres-entrypoint.sh /usr/local/bin/postgres-entrypoint.sh


### PR DESCRIPTION
re n3oltd/work#89

## Summary

Adds `pg_repack` to the postgres image. It rebuilds a bloated table or index online, building
a copy and keeping it in sync before swapping, so the table stays available throughout. The
alternative already available in the image is `VACUUM FULL`, which takes an exclusive lock for
the whole rewrite.

The daily bloat report identifies tables that need rewriting; until now the image carried no
remedy that did not cost an outage. That is tolerable at current data sizes and stops being so
once the large tenants move — the biggest table arriving is 59 GB.

`postgresql-18-repack` is pinned to the major version, so it has to be bumped alongside the
base image; the comment says so at the point where that matters.

## Test plan

- [x] `postgresql-18-repack` resolves from PGDG for trixie at 1.5.3
- [x] Installs the extension control file at `/usr/share/postgresql/18/extension/pg_repack.control`
- [x] Installs the client binary and puts it on `PATH` for the `postgres` user
