### PR TITLE
Let the WAL level and sender count be set per server

### DIFF
--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -9,6 +9,7 @@ sed -i "/archive_mode/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/archive_command/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/wal_level/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/max_wal_senders/d" /var/lib/postgresql/data/postgres/postgresql.conf
+sed -i "/max_replication_slots/d" /var/lib/postgresql/data/postgres/postgresql.conf
 
 sed -i "/logging_collector/d" /var/lib/postgresql/data/postgres/postgresql.conf
 sed -i "/log_directory/d" /var/lib/postgresql/data/postgres/postgresql.conf
@@ -70,8 +71,9 @@ chmod 600 /etc/pgbackrest/pgbackrest.conf
 exec docker-entrypoint.sh postgres \
           -c archive_mode="${POSTGRES_ARCHIVE_MODE:-on}" \
           -c archive_command="pgbackrest --stanza=n3o archive-push %p" \
-          -c wal_level=replica \
-          -c max_wal_senders=3 \
+          -c wal_level="${POSTGRES_WAL_LEVEL:-replica}" \
+          -c max_wal_senders="${POSTGRES_MAX_WAL_SENDERS:-3}" \
+          -c max_replication_slots="${POSTGRES_MAX_REPLICATION_SLOTS:-10}" \
           -c logging_collector=on \
           -c log_directory="log" \
           -c log_filename="postgresql-%Y-%m-%d.log" \


### PR DESCRIPTION
re n3oltd/work#89

## Summary

`wal_level`, `max_wal_senders` and `max_replication_slots` were fixed on the postgres command
line, where nothing outside the image can change them. Logical replication needs
`wal_level = logical` and one walsender per database being replicated — the widest server has
seven databases against a ceiling of three.

All three now come from the environment and default to exactly what was hardcoded, so a server
that sets nothing is byte-identical to before.

## Test plan

- [x] `bash -n` passes on the entrypoint
- [x] Defaults match the previous hardcoded values: `replica`, `3`, and PostgreSQL's own `10`
- [x] `max_replication_slots` is stripped from `postgresql.conf` alongside the other two, so the
      command line remains authoritative after a restore
