### PR TITLE
Let a Dockerfile fetch write somewhere other than its catalogue name

### DIFF
--- a/.github/actions/n3o-dockerfile-fetch/action.yml
+++ b/.github/actions/n3o-dockerfile-fetch/action.yml
@@ -6,8 +6,12 @@ description: >-
 
 inputs:
   dockerfile:
-    description: Catalogue Dockerfile name, written to this path in the workspace.
+    description: Catalogue Dockerfile name.
     required: true
+  path:
+    description: Where to write it. Defaults to the catalogue name, which collides when the calling repository has a directory of that name.
+    required: false
+    default: ''
   assets:
     description: Newline-separated docker/assets names to fetch alongside it, each written to the workspace root.
     required: false
@@ -24,16 +28,21 @@ runs:
     - shell: bash
       env:
         DOCKERFILE: ${{ inputs.dockerfile }}
+        DEST: ${{ inputs.path }}
         ASSETS: ${{ inputs.assets }}
         PREFER_LOCAL: ${{ inputs.prefer-local }}
       run: |
         set -euo pipefail
         catalogue=https://raw.githubusercontent.com/n3oltd/actions/main/docker
 
-        if [ "$PREFER_LOCAL" = "true" ] && [ -f "$DOCKERFILE" ]; then
-          echo "Using the Dockerfile committed at $DOCKERFILE"
+        dest=${DEST:-$DOCKERFILE}
+
+        if [ "$PREFER_LOCAL" = "true" ] && [ -f "$dest" ]; then
+          echo "Using the Dockerfile committed at $dest"
         else
-          curl -fsSL -o "$DOCKERFILE" "$catalogue/$DOCKERFILE"
+          # A directory of the same name makes curl exit with a write error that names nothing.
+          [ -d "$dest" ] && { echo "$dest is a directory; pass a distinct path"; exit 1; }
+          curl -fsSL -o "$dest" "$catalogue/$DOCKERFILE"
         fi
 
         while IFS= read -r asset; do

--- a/.github/workflows/n3o-docker-build-push-postgres.yml
+++ b/.github/workflows/n3o-docker-build-push-postgres.yml
@@ -27,6 +27,7 @@ jobs:
         uses: n3oltd/actions/.github/actions/n3o-dockerfile-fetch@main
         with:
           dockerfile: postgres
+          path: Dockerfile.postgres
           assets: postgres-entrypoint.sh
 
       - id: meta
@@ -41,6 +42,6 @@ jobs:
           builder: ${{ steps.acr.outputs.builder }}
           context: .
           target: final
-          file: postgres
+          file: Dockerfile.postgres
           push: true
           tags: ${{ steps.meta.outputs.version-tag }} , ${{ steps.meta.outputs.latest-tag }}


### PR DESCRIPTION
re n3oltd/work#89

## Summary

The postgres image has not built since 2 August. The fetch step writes the catalogue Dockerfile
to a file named after it, and `devops` has a top-level `postgres/` directory — so `curl -o
postgres` tries to write a file over a directory and exits 23, a write error that names nothing.

The fetch now takes an optional path, and the postgres workflow writes to `Dockerfile.postgres`.
A directory in the way is also caught explicitly, so the next occurrence says what is wrong
rather than failing on an opaque exit code.

`pgbouncer`, `kubectl` and `mssql` pass no path and are unchanged; none of them collides, because
`devops` has no directory of those names.

## Test plan

- [x] Both files parse as YAML
- [x] The collision reproduced: `postgres` is a tree at the top of `devops` `main`, and two
      dispatches failed at exactly this step
- [ ] A dispatched build succeeds and publishes a tag
