### PR TITLE
Ask Dependabot only for major action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    # Actions are pinned to their major tag, which the publisher floats to the
+    # newest patch — only a new major needs a pull request.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Every action here is pinned to its major tag, which the publisher floats to the newest patch — so a minor or patch proposal rewrites a working float into a fixed version, sometimes to an older commit than the float already resolves to. Dependabot now proposes majors only.

Note: `azure/use-kubelogin` is pinned `@v1.3` because that publisher ships no floating `v1` tag, so it cannot follow the rule and will now only be proposed on a major.

## Test plan

- [x] Config parses as YAML