### PR TITLE
Tighten the apply-manifests comments

### DIFF
--- a/.github/workflows/n3o-aks-apply-manifests.yml
+++ b/.github/workflows/n3o-aks-apply-manifests.yml
@@ -1,4 +1,3 @@
-# Applies plain manifests to an AKS cluster and waits for the workloads to settle.
 name: Apply manifests to AKS
 
 on:
@@ -49,8 +48,8 @@ jobs:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           resource-group: ${{ inputs.resource-group }}
 
-      # Secrets are held outside the repository, so a cluster that has never had them applied
-      # would take the workload into CrashLoopBackOff rather than fail here.
+      # Secrets are held outside the repository; without this a cluster missing them reaches
+      # CrashLoopBackOff instead of failing here.
       - name: Check the secrets exist
         if: inputs.require-secrets != ''
         env:


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#89

## Summary

The header comment restated the workflow's own name and earned nothing. The secrets-check comment
said the same thing in twice the words. What survives is the constraint: the secrets are not in the
repository, and without the check a cluster missing them reaches `CrashLoopBackOff` rather than
failing at the step that could say why.

No behaviour changes.

## Test plan

- [x] File still parses as YAML