### PR TITLE
Pass app settings one per line rather than splitting on whitespace

### DIFF
--- a/.github/actions/n3o-webapp-deploy/action.yml
+++ b/.github/actions/n3o-webapp-deploy/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: ''
   app-settings:
-    description: additional app settings, space separated KEY=VALUE pairs
+    description: additional app settings, one KEY=VALUE per line
     required: false
     default: ''
   website-port:
@@ -65,10 +65,16 @@ runs:
           --docker-registry-server-password "$REGISTRY_PASSWORD" \
           --output none
 
-        # shellcheck disable=SC2086 — EXTRA_SETTINGS is a caller-supplied argument list.
+        # One pair per line, never split on whitespace: a value may contain spaces.
+        SETTINGS=(WEBSITES_PORT="$WEBSITE_PORT")
+
+        while IFS= read -r setting; do
+          [ -n "$setting" ] && SETTINGS+=("$setting")
+        done <<< "$EXTRA_SETTINGS"
+
         az webapp config appsettings set \
           --name "$SITE" --resource-group "$GROUP" \
-          --settings WEBSITES_PORT="$WEBSITE_PORT" $EXTRA_SETTINGS \
+          --settings "${SETTINGS[@]}" \
           --output none
 
         az webapp restart --name "$SITE" --resource-group "$GROUP" --output none

--- a/.github/workflows/oauth-static-site-deploy.yml
+++ b/.github/workflows/oauth-static-site-deploy.yml
@@ -67,15 +67,15 @@ jobs:
           azure-credentials: ${{ secrets.azure-credentials }}
           registry-username: ${{ secrets.registry-username }}
           registry-password: ${{ secrets.registry-password }}
-          app-settings: >-
-            OAUTH2_PROXY_CLIENT_ID="${{ inputs.client-id }}"
-            OAUTH2_PROXY_CLIENT_SECRET="${{ secrets.client-secret }}"
-            OAUTH2_PROXY_COOKIE_SECRET="${{ secrets.cookie-secret }}"
-            OAUTH2_PROXY_FOOTER="Copyright © N3O Ltd"
-            OAUTH2_PROXY_CUSTOM_SIGN_IN_LOGO="https://n3oltd.blob.core.windows.net/public-assets/logos/logo.svg"
-            OAUTH2_PROXY_EMAIL_DOMAINS="${{ inputs.email-domains }}"
-            OAUTH2_PROXY_PROVIDER="azure"
-            OAUTH2_PROXY_AZURE_TENANT_ID="${{ inputs.tenant-id }}"
-            OAUTH2_PROXY_OIDC_ISSUER_URL="https://login.microsoftonline.com/${{ inputs.tenant-id }}/v2.0"
-            OAUTH2_PROXY_REVERSE_PROXY="1"
-            OAUTH2_PROXY_REAL_CLIENT_IP_HEADER="X-Forwarded-For"
+          app-settings: |
+            OAUTH2_PROXY_CLIENT_ID=${{ inputs.client-id }}
+            OAUTH2_PROXY_CLIENT_SECRET=${{ secrets.client-secret }}
+            OAUTH2_PROXY_COOKIE_SECRET=${{ secrets.cookie-secret }}
+            OAUTH2_PROXY_FOOTER=Copyright © N3O Ltd
+            OAUTH2_PROXY_CUSTOM_SIGN_IN_LOGO=https://n3oltd.blob.core.windows.net/public-assets/logos/logo.svg
+            OAUTH2_PROXY_EMAIL_DOMAINS=${{ inputs.email-domains }}
+            OAUTH2_PROXY_PROVIDER=azure
+            OAUTH2_PROXY_AZURE_TENANT_ID=${{ inputs.tenant-id }}
+            OAUTH2_PROXY_OIDC_ISSUER_URL=https://login.microsoftonline.com/${{ inputs.tenant-id }}/v2.0
+            OAUTH2_PROXY_REVERSE_PROXY=1
+            OAUTH2_PROXY_REAL_CLIENT_IP_HEADER=X-Forwarded-For


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

`n3o-webapp-deploy` interpolated the caller's settings unquoted, so the shell split them on whitespace. `OAUTH2_PROXY_FOOTER="Copyright © N3O Ltd"` therefore reached the CLI as four arguments and it rejected the second: `Invalid setting format: '©'`.

Every oauth-fronted site has failed to deploy since — Storybook's last success was 30 July, and the five runs after it all failed the same way. The build was fine each time; only the deploy step failed, which is why it went unnoticed.

Settings are now one `KEY=VALUE` per line, read a line at a time into an argument array. That needs no quoting convention and no `eval`, so a value may contain spaces, quotes, backticks or `$` and still arrive whole — the quotes in the old caller were never shell quotes anyway, since the value came from YAML rather than from a shell.

## Test plan

- [x] The parsing handles a value with spaces and a `©`, and a secret containing `"`, a backtick and `$`, yielding exactly one argument each
- [ ] Storybook's deploy goes green on merge — the first oauth site to run