### PR TITLE
Build the Caddy fleets with the Azure DNS module

### DIFF
--- a/docker/n3o-caddy
+++ b/docker/n3o-caddy
@@ -8,7 +8,7 @@
 ########################
 FROM caddy:builder AS builder
 
-RUN xcaddy build --with github.com/ueffel/caddy-brotli
+RUN xcaddy build --with github.com/ueffel/caddy-brotli --with github.com/caddy-dns/azure
 
 ########################
 ### final


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3316

## Summary

First step of replacing HTTP-01 issuance: the shared `n3o-caddy` Dockerfile compiles in `caddy-dns/azure` so fleets can satisfy DNS-01 challenges against the Azure DNS zones. Inert until a Caddyfile opts a host into `tls { dns azure }` — those Caddyfile changes are sequenced after this image and the fleet workload identity land.

## Test plan

- [ ] caddy.yml fleet builds succeed with the module compiled in
- [ ] `caddy list-modules` in the new image shows dns.providers.azure