### PR TITLE
Scrub leaked session state on every pgbouncer server checkin

### DIFF
--- a/docker/assets/pgbouncer-entrypoint.sh
+++ b/docker/assets/pgbouncer-entrypoint.sh
@@ -52,8 +52,6 @@ max_db_connections = ${MAX_CONNECTIONS}
 max_user_connections = ${MAX_CONNECTIONS}
 max_prepared_statements = 100
 server_reset_query = DISCARD ALL
-# transaction pooling skips the reset query by default, so session state (e.g. a migration's
-# SET search_path) leaks onto the next tenant sharing the connection; always is the fix.
 server_reset_query_always = 1
 server_idle_timeout = ${POSTGRES_IDLE_SESSION_TIMEOUT}
 server_fast_close = 1

--- a/docker/assets/pgbouncer-entrypoint.sh
+++ b/docker/assets/pgbouncer-entrypoint.sh
@@ -52,6 +52,9 @@ max_db_connections = ${MAX_CONNECTIONS}
 max_user_connections = ${MAX_CONNECTIONS}
 max_prepared_statements = 100
 server_reset_query = DISCARD ALL
+# transaction pooling skips the reset query by default, so session state (e.g. a migration's
+# SET search_path) leaks onto the next tenant sharing the connection; always is the fix.
+server_reset_query_always = 1
 server_idle_timeout = ${POSTGRES_IDLE_SESSION_TIMEOUT}
 server_fast_close = 1
 client_idle_timeout = 300


### PR DESCRIPTION
## What

Add `server_reset_query_always = 1` to the pgbouncer entrypoint config.

## Why

pgbouncer runs in `pool_mode = transaction`, and in that mode it **skips** `server_reset_query` on connection checkin by default. So any session-level state one client leaves behind rides the shared server connection to the next client on the same tenant DB.

Creating a taxrelief tenant DB runs its DbUp migrations, which are pg_dump output and include `SELECT pg_catalog.set_config('search_path', '', false)` — session-scoped (`is_local = false`), so it survives the script's COMMIT. The empty `search_path` then poisons the next unqualified query on that pooled connection:

```
Npgsql.PostgresException 3F000: no schema has been selected to create in
```

On 2026-08-05 this put `taxrelief-web-qa` into an unrecoverable loop (~600 exceptions in 7 min — the `ReliefPositionSnapshotsPoller` plus API 500s), because `Rdbms.InitializeAsync` only marks a DB initialised after `MigrateMd5HashesAsync` succeeds, so every retry re-hit the poisoned path.

## Fix

`server_reset_query_always = 1` makes pgbouncer run `DISCARD ALL` on **every** server-connection checkin regardless of pool mode, clearing any leaked `search_path`/`SET` before reuse. One line, and it neutralises the entire class of cross-tenant session-state leaks — not just this one migration. Cost is one `DISCARD ALL` round-trip per checkout, negligible and the standard hardening for transaction-pooled pgbouncer.

## Rollout

Config is baked into the `n3o-pgbouncer` image at build. After merge, rebuild/publish the image (the `Build Pgbouncer Container` workflow in devops) and roll the `postgres-*` StatefulSets so sidecars pick up the new default. QA was already unblocked with a manual pgbouncer + pod restart; this stops it recurring the next time tenant DBs are created empty.

re n3oltd/work#3323
