### PR TITLE
Also compile in the Cloudflare DNS module

### DIFF
--- a/docker/n3o-caddy
+++ b/docker/n3o-caddy
@@ -8,7 +8,7 @@
 ########################
 FROM caddy:builder AS builder
 
-RUN xcaddy build --with github.com/ueffel/caddy-brotli
+RUN xcaddy build --with github.com/ueffel/caddy-brotli --with github.com/caddy-dns/azure
 
 ########################
 ### final

--- a/docker/n3o-caddy
+++ b/docker/n3o-caddy
@@ -8,7 +8,7 @@
 ########################
 FROM caddy:builder AS builder
 
-RUN xcaddy build --with github.com/ueffel/caddy-brotli --with github.com/caddy-dns/azure
+RUN xcaddy build --with github.com/ueffel/caddy-brotli --with github.com/caddy-dns/azure --with github.com/caddy-dns/cloudflare
 
 ########################
 ### final


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3316

## Summary

Completes the DNS-provider pair: the charity-owned zones sit on Cloudflare, so the fleets need `caddy-dns/cloudflare` beside the Azure module that merged in #196 (this commit just missed that merge). One rebuild covers both providers.

## Test plan

- [ ] Fleet builds succeed; `caddy list-modules` shows dns.providers.azure and dns.providers.cloudflare