### PR TITLE
Patch workload-identity auth into the Azure DNS module

### DIFF
--- a/docker/n3o-caddy
+++ b/docker/n3o-caddy
@@ -8,7 +8,33 @@
 ########################
 FROM caddy:builder AS builder
 
-RUN xcaddy build --with github.com/ueffel/caddy-brotli --with github.com/caddy-dns/azure --with github.com/caddy-dns/cloudflare
+# libdns/azure authenticates with a client secret or over IMDS, and has no path for the
+# federated token an AKS workload identity supplies, so a fleet running as one cannot answer
+# a DNS-01 challenge (libdns/azure#11). Patch the credential in and build against the result;
+# delete this stage's clone and the --with replacement once upstream carries it. The grep
+# asserts the anchor still exists, so an upstream reshuffle fails the build rather than
+# silently producing an unpatched binary.
+ARG LIBDNS_AZURE_VERSION=v0.5.0
+
+RUN set -eu; \
+    git clone --quiet --depth 1 --branch ${LIBDNS_AZURE_VERSION} https://github.com/libdns/azure /src/libdns-azure; \
+    cd /src/libdns-azure; \
+    test "$(grep -c 'azidentity.NewManagedIdentityCredential(nil)' client.go)" = "1"; \
+    awk '/azidentity.NewManagedIdentityCredential\(nil\)/ && !done { \
+            print "\t\t\tif wiCred, wiErr := azidentity.NewWorkloadIdentityCredential(nil); wiErr == nil {"; \
+            print "\t\t\t\tcredentials = append(credentials, wiCred)"; \
+            print "\t\t\t}"; \
+            print ""; \
+            done = 1 \
+         } { print }' client.go > client.go.patched; \
+    mv client.go.patched client.go; \
+    grep -q 'NewWorkloadIdentityCredential' client.go
+
+RUN xcaddy build \
+      --with github.com/ueffel/caddy-brotli \
+      --with github.com/caddy-dns/azure \
+      --with github.com/caddy-dns/cloudflare \
+      --with github.com/libdns/azure=/src/libdns-azure
 
 ########################
 ### final


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3316

## Summary

`libdns/azure`, which `caddy-dns/azure` wraps, builds its credential by hand — a client secret when `tenant_id`/`client_id`/`client_secret` are set, otherwise `NewManagedIdentityCredential` over IMDS. `WorkloadIdentityCredential` is not in the chain. So a fleet running as an AKS workload identity carries the federated token, never reads it, calls IMDS instead, and cannot answer a DNS-01 challenge. Releasing the wildcards on that basis took every host covered by one off TLS entirely (devops#420, reverted in devops#423).

The builder stage now clones the module at a pinned tag, appends a `WorkloadIdentityCredential` to the chain ahead of the managed-identity one, and builds against the result via `--with github.com/libdns/azure=/src/libdns-azure`.

Two things make it safe to carry:

- `NewWorkloadIdentityCredential` returns an error when the workload-identity environment variables are absent, so skipping the append on error leaves every non-workload-identity build behaving byte-for-byte as it does today.
- The `grep -c` assertion fails the build if the anchor line stops matching exactly once, so an upstream reshuffle breaks loudly instead of silently producing an unpatched binary.

Requested upstream as [libdns/azure#11](https://github.com/libdns/azure/issues/11). When that lands, delete the clone and the `--with` replacement — nothing else changes.

## Test plan

Built locally with this Dockerfile, which is exactly what CI does:

- [x] `xcaddy build` succeeds with the replacement; patched `setupClient` reviewed in the builder stage
- [x] Final `caddy-sites` image validates its routes file and reports Caddy v2.11.4
- [x] `caddy list-modules` shows `dns.providers.azure` and `dns.providers.cloudflare`
- [x] `azidentity.(*WorkloadIdentityCredential)` symbols are linked into the shipped binary
- [ ] After merge: rebuild, then re-land the wildcards on `proxy-backend-qa` **alone** and watch a real certificate issue over dns-01 before anything goes near the sites fleet