### PR TITLE
Give validation a stand-in for the Cloudflare token

### DIFF
--- a/docker/n3o-caddy
+++ b/docker/n3o-caddy
@@ -48,7 +48,10 @@ COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY ${FLEET}/Caddyfile ${FLEET}/routes.*.caddy /etc/config/
 
 # The environments come from the routes the fleet ships, so one added later is still checked.
+# DNS provider modules reject a malformed credential when the config is provisioned, which
+# validation does, so each secret a routes file reads needs a syntactically valid stand-in here.
 RUN set -eu; \
+    export CLOUDFLARE_API_TOKEN=validate_only_placeholder_0000000000; \
     for routes in /etc/config/routes.*.caddy; do \
       environment=${routes#/etc/config/routes.}; \
       environment=${environment%.caddy}; \


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3316

## Summary

`caddy validate` provisions every module in the config, and `caddy-dns/cloudflare` rejects a credential that does not match its token shape at provision time. The build has no secrets, so a routes file reading `{env.CLOUDFLARE_API_TOKEN}` fails validation with `API token '' appears invalid` — CI, not production, but it blocks the fleet image entirely.

The validation step now exports a syntactically valid stand-in. The routes files keep `{env.CLOUDFLARE_API_TOKEN}`, so a pod started without the real value still fails loudly at provision rather than quietly using a placeholder and having certificates fail later.

Caught by building the sites fleet locally against the pending routes change; without this that merge would have failed CI.

## Test plan

- [x] `caddy-sites` image builds and validates with the Cloudflare `tls` blocks present
- [x] Adapted config shows 61 subjects on the cloudflare DNS challenge and 55 on HTTP-01