### PR TITLE
Point the QA trigger actions at the renamed deployment workflows

### DIFF
--- a/.github/actions/n3o-trigger-platforms-app-deployment-qa/action.yml
+++ b/.github/actions/n3o-trigger-platforms-app-deployment-qa/action.yml
@@ -15,6 +15,6 @@ runs:
     - name: run
       shell: bash
       run: |
-        gh workflow run mobile-app-platforms${{ inputs.subscription-id }}-qa-deployment.yml --repo n3oltd/deployments
+        gh workflow run mobile-app-platforms${{ inputs.subscription-id }}-qa.yml --repo n3oltd/deployments
       env:
         GH_TOKEN: ${{ inputs.workflows-token }}

--- a/.github/actions/n3o-trigger-platforms-js-deployment-qa/action.yml
+++ b/.github/actions/n3o-trigger-platforms-js-deployment-qa/action.yml
@@ -12,6 +12,6 @@ runs:
     - name: run
       shell: bash
       run: |
-        gh workflow run eu1-qa-platforms-js-deployment.yml --repo n3oltd/deployments
+        gh workflow run eu1-platforms-js-qa.yml --repo n3oltd/deployments
       env:
         GH_TOKEN: ${{ inputs.workflows-token }}


### PR DESCRIPTION
re n3oltd/work#3341

## Summary

The deployment roller rename (n3oltd/deployments#65, merged this morning) moved every deployment workflow to the new naming scheme — `eu1-qa-platforms-js-deployment.yml` became `eu1-platforms-js-qa.yml`, and `mobile-app-platforms<id>-qa-deployment.yml` became `mobile-app-platforms<id>-qa.yml`.

Two composite actions here still dispatch the old filenames, so every caller now fails with `HTTP 422: Workflow does not have 'workflow_dispatch' trigger`:

- `n3o-trigger-platforms-js-deployment-qa` — currently failing the Deploy to QA job on every fe-platforms Platforms JS CI run
- `n3o-trigger-platforms-app-deployment-qa` — same rename pattern, will fail on its next use

Both now dispatch the new names, which exist on `n3oltd/deployments@main` with `workflow_dispatch` triggers. These were the only two references to the old filenames in this repo.

Since callers reference these actions `@main`, the fix takes effect for all of them immediately on merge — the failed Deploy to QA job in fe-platforms can then simply be re-run.

## Test plan

- [x] Verified `eu1-platforms-js-qa.yml` and `mobile-app-platforms6e-qa.yml` exist on n3oltd/deployments main with `workflow_dispatch`
- [x] `grep` over this repo shows no remaining references to the retired `-deployment.yml` names
- [ ] After merge: re-run Deploy to QA in fe-platforms Platforms JS CI and confirm the dispatch succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)