### PR TITLE
Label triaged issues with the workflow's own token

### DIFF
--- a/.github/workflows/n3o-auto-triage-issues.yml
+++ b/.github/workflows/n3o-auto-triage-issues.yml
@@ -1,5 +1,5 @@
 # Reusable workflow that auto-labels newly opened issues that have no labels,
-# applying a configurable triage label via a GitHub App token.
+# applying a configurable triage label.
 # Call it from a repo's issue-opened workflow to flag untriaged issues.
 name: n3o auto-triage new issue
 
@@ -15,18 +15,15 @@ jobs:
   mark:
     if: github.event.issue.labels[0] == null
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
 
     steps:
-      - name: app token
-        id: app-token
-        uses: n3oltd/actions/.github/actions/n3o-app-token@main
-        with:
-          app-id: ${{ secrets.N3O_APP_ID }}
-          private-key: ${{ secrets.N3O_APP_PRIVATE_KEY }}
-
+      # A label applied under github.token does not trigger workflows listening for
+      # `issues: labeled`.
       - name: apply triage label
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3350

## Summary

The triage label is applied to the repository the workflow is already running in, which `github.token` covers. Minting an app token spent the shared installation allowance for access the job had anyway — and that allowance is what CI, the CLI and the tracker compete over.

`github.token` is budgeted per repository and draws on no shared allowance, so this is free capacity.

The `permissions:` block is explicit because the workflow had none. Without it the job inherits the repository or organisation default, and would 403 wherever that default is read-only.

One behavioural difference worth knowing: a label applied under `github.token` does not trigger workflows listening for `issues: labeled`. Nothing in this organisation listens for it today, and the comment in the file records the constraint so a future listener is not written against a trigger that will not fire.

## Test plan

- [x] Confirmed the only action is `gh issue edit --repo ${{ github.repository }}` — same-repo, so within `github.token`'s reach
- [ ] Open an unlabelled issue in a calling repository and confirm the triage label is applied
