### PR TITLE
Build one Caddy image for every fleet

### DIFF
--- a/docker/assets/caddy-Caddyfile
+++ b/docker/assets/caddy-Caddyfile
@@ -1,0 +1,10 @@
+# A fleet's routing is mounted over this directory; an import glob matching nothing is valid
+# Caddy that serves nothing, so the mount is what a cutover must be verified against.
+# A cluster fleet obtains its own certificates and a fleet behind App Service must not, which
+# is the only thing CADDY_GLOBAL_OPTIONS carries today.
+{
+	email mail@n3o.ltd
+	{$CADDY_GLOBAL_OPTIONS}
+}
+
+import /etc/caddy/routes/*.caddy

--- a/docker/n3o-caddy
+++ b/docker/n3o-caddy
@@ -1,7 +1,5 @@
-# n3o-caddy — a Caddy routing fleet.
-#
-# Build-args:
-#   FLEET  context-relative directory holding the fleet's Caddyfile and its routes.*.caddy
+# n3o-caddy — the estate's Caddy. Every routing fleet runs this one image; what a fleet serves
+# is mounted at /etc/caddy/routes and never built in, so nothing here knows which fleet it is.
 
 ########################
 ### caddy with brotli, which the default build omits
@@ -41,23 +39,19 @@ RUN xcaddy build \
 ########################
 FROM caddy:latest AS final
 
-ARG FLEET
-
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 
-COPY ${FLEET}/Caddyfile ${FLEET}/routes.*.caddy /etc/config/
+COPY caddy-Caddyfile /etc/config/Caddyfile
 
-# The environments come from the routes the fleet ships, so one added later is still checked.
-# DNS provider modules reject a malformed credential when the config is provisioned, which
-# validation does, so each secret a routes file reads needs a syntactically valid stand-in here.
+# A routes file naming a module the binary lacks fails at run time, on a fleet, with the config
+# already deployed; this is the last point at which that is a build failure instead.
 RUN set -eu; \
-    export CLOUDFLARE_API_TOKEN=validate_only_placeholder_0000000000; \
-    for routes in /etc/config/routes.*.caddy; do \
-      environment=${routes#/etc/config/routes.}; \
-      environment=${environment%.caddy}; \
-      echo "validating ${environment}"; \
-      CADDY_ENVIRONMENT=${environment} caddy validate --config /etc/config/Caddyfile --adapter caddyfile; \
-    done
+    mkdir -p /etc/caddy/routes; \
+    modules=$(caddy list-modules); \
+    for module in http.encoders.br dns.providers.azure dns.providers.cloudflare; do \
+      echo "$modules" | grep -qx "$module"; \
+    done; \
+    caddy validate --config /etc/config/Caddyfile --adapter caddyfile
 
 # The base exposes 80, 443 and 2019 and carries /data; a fleet behind App Service listens here.
 EXPOSE 8080


### PR DESCRIPTION
## Summary

`n3o-caddy` becomes one image instead of six. It was built once per Caddy fleet with a `FLEET` build-arg naming the directory whose `Caddyfile` and `routes.*.caddy` were copied in; the binary was identical every time and only the baked config differed. The build-arg and the copy go, and the image gets a Caddyfile that names no hosts, no upstreams and no environment — it imports whatever is mounted at `/etc/caddy/routes`.

The two things a fleet's config must still say that the image cannot are handled where they belong. `email` is the estate's ACME account and is the same for every fleet, so it stays in the image. Whether a fleet manages its own certificates differs by where it runs — a cluster fleet must, a fleet behind App Service must not — so it arrives as `CADDY_GLOBAL_OPTIONS` from the target, which is unset for cluster fleets and `auto_https off` for App Service ones.

Build-time validation changes character. There is no config here to validate any more, so instead the build asserts the binary carries the modules a fleet's routes will name: brotli, and the Azure and Cloudflare DNS providers. That check has real teeth — a routes file naming a module the binary lacks used to fail this build through the config that named it, and would otherwise now fail at run time on a fleet with the config already deployed.

Re n3oltd/work#3336.

## Test plan

- [x] The bootstrap Caddyfile adapts on real Caddy in both shapes: with `CADDY_GLOBAL_OPTIONS` unset (a cluster fleet) and set to `auto_https off` (an App Service fleet). Composed with each fleet's routes, the compiled JSON matches what that fleet runs today — byte-identical for the cluster fleets, and identical in the HTTP server for the App Service ones, which additionally gain an ACME issuer policy that is never consulted because automatic HTTPS is off.
- [x] `caddy list-modules | grep -qx <module>` verified against the real output format, which is one bare module id per line.
- [ ] Not exercised here: the image build itself, which runs from n3oltd/devops. Nothing consumes this Dockerfile until that repository's workflow stops passing `FLEET`.

## Merge order

Safe to merge at any time — nothing builds this until n3oltd/devops's caddy workflow stops passing `FLEET`, and that workflow change must not merge until every fleet is reading its config from a mount.
