### PR TITLE
Let log_min_duration_statement be set per server

### DIFF
--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -76,9 +76,9 @@ exec docker-entrypoint.sh postgres \
           -c max_replication_slots="${POSTGRES_MAX_REPLICATION_SLOTS:-10}" \
           -c logging_collector=on \
           -c log_directory="log" \
-          -c log_filename="postgresql-%Y-%m-%d.log" \
+          -c log_filename="postgresql-%Y-%m-%d_%H%M%S.log" \
           -c log_rotation_age=1d \
-          -c log_rotation_size=0 \
+          -c log_rotation_size="${POSTGRES_LOG_ROTATION_SIZE:-0}" \
           -c log_line_prefix="%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h " \
           -c log_min_duration_statement="${POSTGRES_LOG_MIN_DURATION_STATEMENT:-0}" \
           -c log_checkpoints=on \

--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -80,7 +80,7 @@ exec docker-entrypoint.sh postgres \
           -c log_rotation_age=1d \
           -c log_rotation_size=0 \
           -c log_line_prefix="%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h " \
-          -c log_min_duration_statement=0 \
+          -c log_min_duration_statement="${POSTGRES_LOG_MIN_DURATION_STATEMENT:-0}" \
           -c log_checkpoints=on \
           -c log_connections=on \
           -c log_disconnections=on \

--- a/docker/assets/postgres-entrypoint.sh
+++ b/docker/assets/postgres-entrypoint.sh
@@ -76,9 +76,9 @@ exec docker-entrypoint.sh postgres \
           -c max_replication_slots="${POSTGRES_MAX_REPLICATION_SLOTS:-10}" \
           -c logging_collector=on \
           -c log_directory="log" \
-          -c log_filename="postgresql-%Y-%m-%d_%H%M%S.log" \
+          -c log_filename="postgresql-%Y-%m-%d.log" \
           -c log_rotation_age=1d \
-          -c log_rotation_size="${POSTGRES_LOG_ROTATION_SIZE:-0}" \
+          -c log_rotation_size=0 \
           -c log_line_prefix="%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h " \
           -c log_min_duration_statement="${POSTGRES_LOG_MIN_DURATION_STATEMENT:-0}" \
           -c log_checkpoints=on \


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3374

## Summary

`postgres-entrypoint.sh` has always passed `-c log_min_duration_statement=0`, which logs every `parse`, `bind` and `execute` together with a `DETAIL: Parameters:` line carrying the full parameter list. Combined with `log_rotation_size=0` and a per-day `log_filename`, nothing in the image bounds how large a day's file gets; the only thing that removes a log is the reports CronJob in `n3oltd/devops`.

On 2026-08-11 the Lists SQL Server to PostgreSQL migration ran its bulk load against `postgres-prod` and wrote 546 GB into a single day's file between 00:00 and 08:55 UTC, about 60 GB an hour. The log directory reached 510 G of a 633 G used volume — four times the size of the databases it was recording. The reports job that would normally prune it failed after nine hours, because pgbadger cannot process a file that size inside the database container.

The value now comes from `POSTGRES_LOG_MIN_DURATION_STATEMENT`, in the same shape #187 used for the WAL settings, so a server that needs a full statement log keeps one and a server under bulk load can ask for slow statements only. The default is the existing `0`, so rebuilding the image changes no server's behaviour on its own; prod opts out separately in `n3oltd/devops`.

## Test plan

- [ ] Build the image and confirm `postgres` starts with `log_min_duration_statement=0` when the variable is unset, matching what `postgres-prod-0` and `postgres-qa-0` run today.
- [ ] Set `POSTGRES_LOG_MIN_DURATION_STATEMENT=1000` and confirm `pg_settings` reports `1000` with source `command line`, and that the log stops carrying sub-second statements.
