### PR TITLE
Fail the image build when the package filter matches nothing

### DIFF
--- a/docker/n3o-node
+++ b/docker/n3o-node
@@ -44,7 +44,7 @@ if [ -f "${PACKAGE}/pnpm-lock.yaml" ]; then
 fi
 cp .npmrc .npmrc.bak 2>/dev/null || touch .npmrc.bak
 printf "\n//npm.pkg.github.com/:_authToken=%s\n" "$GH_PAT" >> .npmrc
-pnpm install --frozen-lockfile --filter "${PACKAGE}..."
+pnpm install --frozen-lockfile --fail-if-no-match --filter "${PACKAGE}..."
 mv .npmrc.bak .npmrc
 INSTALL
 RUN chmod +x /usr/local/bin/install-deps
@@ -54,7 +54,7 @@ COPY <<'RUNBUILD' /usr/local/bin/run-build
 set -eu
 if [ -f "${PACKAGE}/package-lock.json" ]; then cd "${PACKAGE}" && exec npm run "${BUILD_SCRIPT}"; fi
 if [ -f "${PACKAGE}/pnpm-lock.yaml" ]; then cd "${PACKAGE}" && exec pnpm run "${BUILD_SCRIPT}"; fi
-exec pnpm --filter "${PACKAGE}" run "${BUILD_SCRIPT}"
+exec pnpm --fail-if-no-match --filter "${PACKAGE}" run "${BUILD_SCRIPT}"
 RUNBUILD
 RUN chmod +x /usr/local/bin/run-build
 


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

pnpm exits zero when a `--filter` matches no project, so a package missing from the build context sails through install and build empty-handed and the failure surfaces stages later at a copy step, naming only a path. Both workspace filter invocations in `n3o-node` now pass `--fail-if-no-match`, so the first command that cannot see the package kills the build and names the filter. Found when the platforms pages app was still in the frontend's `.dockerignore`.

## Test plan

- [x] Flag added to the two workspace-filter invocations only; self-contained npm-root paths untouched
- [ ] Existing app builds (cloud, engage, storybook) pass unchanged