### PR TITLE
Keep the build manifest out of the served static root

### DIFF
--- a/docker/n3o-node
+++ b/docker/n3o-node
@@ -82,6 +82,8 @@ ARG PORT=8080
 ENV APP_BASE_PATH=${BASE_PATH}
 ENV APP_ENV_PREFIX=${ENV_PREFIX}
 COPY --from=build /repo/${OUTPUT_DIR} /srv${BASE_PATH}
+# The build manifest is a version-pinned dependency inventory, never content to serve.
+RUN rm -rf /srv${BASE_PATH}.vite
 # Config arrives here rather than at the compiler, so the artifact tested in one environment
 # is the one promoted to the next, and a restart re-reads it. APP_BASE_HREF substitutes
 # __APP_BASE__, so one image serves under different public paths.


### PR DESCRIPTION
no-work-issue

Static-variant images copy the app's build output wholesale into the served root, and the catch-all `file_server` then serves every file in it. Vite's build manifest (`.vite/manifest.json`) is now part of that output wherever `build.manifest` is enabled, and it is a version-pinned inventory of every dependency in the bundle graph — exactly the input CVE matching wants — publicly fetchable at `/.vite/manifest.json`. The manifest exists for build tooling (the frontend repo's size gate reads it), not for serving: the static stage now deletes it after the copy, so it can never reach a public origin regardless of which apps enable it. Server-variant images are unaffected — they serve only what the app's own server chooses to.

## Test plan

- [x] The removal runs after the output copy and before anything reads the served root
- [ ] Next catalogue build of a static app: `curl https://<host>/.vite/manifest.json` returns 404