### PR TITLE
Let npm-publish ship a package at its committed version

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -16,6 +16,11 @@ inputs:
     required: false
     default: ''
 
+  use-package-version:
+    description: Publish each package at the version committed in its package.json instead of stamping a date-based one. Mutually exclusive with version-suffix.
+    required: false
+    default: 'false'
+
   before-sha:
     description: When set, only packages whose own folder changed since this SHA are published (requires fetch-depth 0)
     required: false
@@ -37,6 +42,10 @@ runs:
     - name: npm publish
       shell: bash
       run: |
+        if [ "${{ inputs.use-package-version }}" = "true" ] && [ "${{ inputs.version-suffix }}" != "" ]; then
+          echo "::error::use-package-version publishes the committed version and version-suffix stamps a new one; set one, not both."
+          exit 1
+        fi
         version=$(date -u +"%Y.%m.%d")-${{ github.run_number }}
         packageDirectories=$(echo '${{ inputs.package-directories }}' | jq -c -r '.[]')
         after="${{ inputs.after-sha }}"; [ -z "$after" ] && after=HEAD
@@ -48,16 +57,20 @@ runs:
             fi
           fi
           ( cd $packageDirectory;
-            if [ "${{ inputs.version-suffix }}" != "" ];then
-              npm version $version --preid=${{ inputs.version-suffix }}
-            else
-              npm version $version;
+            # A committed version belongs to the caller; stamping one would overwrite it.
+            if [ "${{ inputs.use-package-version }}" != "true" ]; then
+              if [ "${{ inputs.version-suffix }}" != "" ];then
+                npm version $version --preid=${{ inputs.version-suffix }}
+              else
+                npm version $version;
+              fi
             fi
             echo "//npm.pkg.github.com/:_authToken=${{ inputs.access-token }}" >> .npmrc;
             echo "@n3oltd:registry=https://npm.pkg.github.com" >> .npmrc;
             name=$(npm pkg get name | tr -d '"')
             effective=$(npm pkg get version | tr -d '"')
-            # An already-published version means a rerun after a partial publish: done, not an error.
+            # An already-published version means a rerun after a partial publish, or a committed
+            # version that already shipped: done, not an error.
             if npm view "$name@$effective" version > /dev/null 2>&1; then
               echo "skip (already published): $name@$effective"
             elif [ "${{ inputs.version-suffix }}" != "" ];then

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -72,8 +72,6 @@ runs:
             # An already-published version means a rerun after a partial publish, or a committed
             # version that already shipped: done, not an error.
             if npm view "$name@$effective" version > /dev/null 2>&1; then
-              # On the committed-version path a skip is also the forgot-to-bump outcome,
-              # so it surfaces in the run summary rather than only deep in the log.
               if [ "${{ inputs.use-package-version }}" = "true" ]; then
                 echo "::notice::skip (already published): $name@$effective"
               else

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -72,7 +72,13 @@ runs:
             # An already-published version means a rerun after a partial publish, or a committed
             # version that already shipped: done, not an error.
             if npm view "$name@$effective" version > /dev/null 2>&1; then
-              echo "skip (already published): $name@$effective"
+              # On the committed-version path a skip is also the forgot-to-bump outcome,
+              # so it surfaces in the run summary rather than only deep in the log.
+              if [ "${{ inputs.use-package-version }}" = "true" ]; then
+                echo "::notice::skip (already published): $name@$effective"
+              else
+                echo "skip (already published): $name@$effective"
+              fi
             elif [ "${{ inputs.version-suffix }}" != "" ];then
               npm publish --tag=${{ inputs.version-suffix }}
             else


### PR DESCRIPTION
no-work-issue

This action was written for packages whose versions nobody chooses. The generated API-client and codegen-types packages are stamped `date -u +%Y.%m.%d-<run_number>` at publish time, and that is correct for them: there is no human-meaningful version for a package that is regenerated from a backend contract, so the action owning version generation is the right design.

platforms.js inverts that. Its version is picked by a person and committed to `apps/platforms-js/package.json`, and the frontend nightly is built around that fact — it reads the committed version, asks the registry whether *that* version exists, and publishes only if it does not. Detection against the registry rather than a baseline diff is deliberate there, so a bump that was missed one night is still pending the next.

Those two models cannot both be served by an action that always stamps. Handed a package committed at `2026.8.16-1`, this action publishes `2026.08.17-<run_number>` and rewrites `package.json` on the way, discarding the version the caller chose. So the version-ownership question becomes an input: `use-package-version` (default `false`) tells the action the caller owns the version, and the stamping step is skipped entirely.

Everything downstream already behaves correctly once stamping is skipped, which is why this is a small change. The publish tag needs no branch of its own — with `version-suffix` necessarily empty on this path, the existing `else` arm already publishes `--tag=latest`. And the already-published guard needs no change either, because it re-reads the effective version out of `package.json` (`npm pkg get version`) rather than reusing the stamped `$version`, so with stamping skipped it queries the committed version and skips a version that has already shipped. That guard was close to inert before: a run-number-derived version is new on every run, so it could only ever fire on a rerun after a partial publish. With a committed version it becomes a real gate, which is exactly what "publish if unpublished" needs.

The two inputs are mutually exclusive — one says the caller owns the version, the other asks for a new one to be stamped — so setting both fails immediately with a message saying so, rather than silently letting one win.

### Existing callers

Both callers of this action were checked and neither is affected, because neither sets the new input:

- `n3o-dotnet-build-pack-push.yml` passes `package-directories`, `access-token` and `version-suffix`.
- `n3oltd/backend`'s `main-ci.yml` passes `package-directories`, `access-token`, `before-sha` and `after-sha` — the hundreds-of-SDK-packages path.

## Test plan

Both paths were dry-run at shell level, driving the real `run:` block extracted from `action.yml` with `npm`, `git` and `date` stubbed to log every invocation, over two package directories.

- [x] **Default path is unchanged.** For each of the three shapes the real callers produce, the command log from this branch is identical to the log from `origin/main`: plain default, `version-suffix=beta` (the `n3o-dotnet-build-pack-push` shape), and `before-sha`/`after-sha` change gating with one directory unchanged (the `main-ci` shape). The already-published skip path is identical too.
- [x] Default still stamps and tags as before — `npm version 2026.08.17-42` then `npm publish --tag=latest`, and with a suffix `npm version 2026.08.17-42 --preid=beta` then `npm publish --tag=beta`.
- [x] `use-package-version: true` issues **no `npm version` at all**, publishes `@n3oltd/alpha@2026.8.16-1` with `--tag=latest`, and leaves the committed version in `package.json` untouched.
- [x] The guard reads the right version on the new path: with `2026.8.16-1` already in the registry it queries `@n3oltd/alpha@2026.8.16-1` and reports `skip (already published)` without publishing.
- [x] `use-package-version: true` together with `version-suffix` exits 1 before running any command, printing the `::error::`.
- [x] `use-package-version: true` composes with change gating — an unchanged directory still reports `skip (unchanged)`.
- [x] The YAML parses and declares the new input; both rendered paths pass `bash -n`.
- [ ] Verified end to end by the frontend PR that adopts it, which must merge after this one.
