### PR TITLE
Let n3o-node-setup bootstrap pnpm through corepack

### DIFF
--- a/.github/actions/n3o-node-setup/action.yml
+++ b/.github/actions/n3o-node-setup/action.yml
@@ -30,7 +30,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # corepack, not a native pnpm install; the self-hosted image lacks libatomic.so.1.
     - if: inputs.pnpm == 'true'
       shell: bash
       run: corepack enable

--- a/.github/actions/n3o-node-setup/action.yml
+++ b/.github/actions/n3o-node-setup/action.yml
@@ -23,10 +23,17 @@ inputs:
   cache-dependency-path:
     description: Lockfile path(s) the cache key derives from.
     required: false
+  pnpm:
+    description: Set "true" to enable pnpm via corepack before Node setup.
+    required: false
 
 runs:
   using: "composite"
   steps:
+    # corepack, not a native pnpm install; the self-hosted image lacks libatomic.so.1.
+    - if: inputs.pnpm == 'true'
+      shell: bash
+      run: corepack enable
     - uses: actions/setup-node@v7
       with:
         node-version: ${{ inputs.node-version }}


### PR DESCRIPTION
no-work-issue

Frontend workflow jobs bootstrap pnpm in two divergent ad-hoc ways — `pnpm/action-setup` (installs a native binary the self-hosted image cannot load, so those jobs only ever ran on the billable lane) and inline `corepack enable` (works everywhere). There was no canonical home for the concern, which is how the divergence survived. `n3o-node-setup` already owns the adjacent Node and registry setup, so it now takes an opt-in `pnpm` input that enables pnpm through corepack before Node setup runs — before, because a `cache: pnpm` restore needs pnpm on the path. Callers that pass nothing are untouched.

## Test plan

- [x] Default path unchanged — the new step is conditional on the input
- [ ] First adopting caller (frontend nightlies publish job) runs green on the free fleet