### PR TITLE
Install the pnpm shims to a writable directory

### DIFF
--- a/.github/actions/n3o-node-setup/action.yml
+++ b/.github/actions/n3o-node-setup/action.yml
@@ -30,9 +30,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # corepack symlinks beside the PATH node by default; the self-hosted image's is root-owned.
     - if: inputs.pnpm == 'true'
       shell: bash
-      run: corepack enable
+      run: |
+        mkdir -p "$RUNNER_TEMP/corepack"
+        corepack enable --install-directory "$RUNNER_TEMP/corepack" pnpm
+        echo "$RUNNER_TEMP/corepack" >> "$GITHUB_PATH"
     - uses: actions/setup-node@v7
       with:
         node-version: ${{ inputs.node-version }}


### PR DESCRIPTION
no-work-issue

The first fleet run of `n3o-node-setup`'s pnpm path failed: `corepack enable` symlinks its shims beside whatever `node` is first on PATH, and at that point in the composite — deliberately before Node setup — that is the image's system node in root-owned `/usr/bin` (EACCES). Hosted runners masked this because their `/usr/local/bin` is runner-writable, which is how #212 tested green. The shims now go to `$RUNNER_TEMP/corepack` (corepack requires the directory to exist, hence the `mkdir`) and that directory joins `GITHUB_PATH`, so the later `setup-node` and every subsequent step resolve pnpm from it regardless of where node lives. Failing run: n3oltd/frontend/actions/runs/32012926109.

## Test plan

- [x] `corepack enable --install-directory` semantics verified locally: directory must pre-exist; pnpm/pnpx shims land in it and resolve
- [ ] Re-dispatched frontend nightly (platformsJs=true) publish job runs green on the free fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)