### PR TITLE
Stamp the image calver and commit into .NET builds

### DIFF
--- a/.github/workflows/n3o-docker-build-push.yml
+++ b/.github/workflows/n3o-docker-build-push.yml
@@ -141,6 +141,8 @@ jobs:
             echo "args<<EOF"
             echo "FEED_URL=https://nuget.pkg.github.com/n3oltd/index.json"
             echo "PAT=${{ env.GH_PAT }}"
+            echo "BUILD_VERSION=${{ steps.metadata.outputs.version }}"
+            echo "COMMIT_SHA=${{ github.sha }}"
             if [[ -n "${{ inputs.sentry-project }}" ]]; then
               echo "REACT_APP_SENTRY_RELEASE=${{ steps.metadata.outputs.version }}"
               echo "VITE_SENTRY_RELEASE=${{ steps.metadata.outputs.version }}"

--- a/docker/n3o-dotnet
+++ b/docker/n3o-dotnet
@@ -27,9 +27,8 @@ ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS="{\"endpointCredentials\": [{\"endpoint\":
 ENV PROJECT=${PROJECT}
 ENV DLL=.dll
 
-# InformationalVersion rather than Version: a channel-prefixed calver such as beta-2026.8.17.42 is
-# not a valid assembly version, and this is the only stamp anything reads. ENV so the publish stage,
-# which does not inherit ARGs, sees the same values
+# A channel-prefixed calver is not a valid assembly version, so the stamp goes on
+# InformationalVersion. ENV because the publish stage does not inherit ARGs
 ENV INFORMATIONAL_VERSION="${BUILD_VERSION}+${COMMIT_SHA}"
 
 COPY . .

--- a/docker/n3o-dotnet
+++ b/docker/n3o-dotnet
@@ -1,4 +1,4 @@
-﻿ARG VARIANT=base
+ARG VARIANT=base
 
 ########################
 ### base
@@ -17,6 +17,8 @@ ARG PAT
 ARG PROJECT
 ARG PROJECT_PATH
 ARG CONFIGURATION
+ARG BUILD_VERSION=0.0.0
+ARG COMMIT_SHA=unknown
 
 WORKDIR /src
 
@@ -25,6 +27,11 @@ ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS="{\"endpointCredentials\": [{\"endpoint\":
 ENV PROJECT=${PROJECT}
 ENV DLL=.dll
 
+# InformationalVersion rather than Version: a channel-prefixed calver such as beta-2026.8.17.42 is
+# not a valid assembly version, and this is the only stamp anything reads. ENV so the publish stage,
+# which does not inherit ARGs, sees the same values
+ENV INFORMATIONAL_VERSION="${BUILD_VERSION}+${COMMIT_SHA}"
+
 COPY . .
 WORKDIR "/src/${PROJECT_PATH}"
 
@@ -32,7 +39,7 @@ RUN apt-get update
 RUN dotnet nuget update source n3oltd -u n3oltd -p ${PAT} --store-password-in-clear-text
 # No -o here: -o overrides every project's OutputPath, breaking build-time codegen targets
 # that exec a sibling project's dll from its own bin/. The publish stage produces /app.
-RUN dotnet build -c "${CONFIGURATION}"
+RUN dotnet build -c "${CONFIGURATION}" -p:InformationalVersion="${INFORMATIONAL_VERSION}"
 
 ########################
 ### publish
@@ -41,7 +48,7 @@ FROM build AS publish
 
 ARG PROJECT
 
-RUN dotnet publish "${PROJECT}.csproj" -c "${CONFIGURATION}" -o /app
+RUN dotnet publish "${PROJECT}.csproj" -c "${CONFIGURATION}" -o /app -p:InformationalVersion="${INFORMATIONAL_VERSION}"
 
 ########################
 ### variant-base


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3404

## Summary

.NET images are built with no version stamp at all, so every assembly in every backend reports
`1.0.0`. Verified inside a running production pod: the entry-point DLL's informational version is
`1.0.0` and `deps.json` agrees.

That breaks Sentry suspect-commit attribution outright. The build registers a Sentry release under
the image calver (`2026.8.17.<run_number>`, from `n3o-image-tags`) while the runtime tags events
with the *deployment* version (`2026.08.17.2`, a different scheme with zero-padding). The two sets
can never intersect, so backend Sentry holds two disjoint release namespaces and no event resolves
to a commit.

This stamps the calver and the commit sha into the built assemblies, so the runtime can report the
version the pipeline actually registered.

```dockerfile
ARG BUILD_VERSION=0.0.0
ARG COMMIT_SHA=unknown

ENV INFORMATIONAL_VERSION="${BUILD_VERSION}+${COMMIT_SHA}"

RUN dotnet build -c "${CONFIGURATION}" -p:InformationalVersion="${INFORMATIONAL_VERSION}"
```

and the workflow supplies both to every image it builds:

```yaml
echo "BUILD_VERSION=${{ steps.metadata.outputs.version }}"
echo "COMMIT_SHA=${{ github.sha }}"
```

## Two choices worth explaining

**`InformationalVersion` rather than `Version` + `SourceRevisionId`.** The obvious pairing —
`-p:Version` for the calver and `-p:SourceRevisionId` for the sha, letting the SDK compose
`1.2.3+sha` — fails for channel builds: `n3o-image-tags` prefixes the channel, so the version is
`beta-2026.8.17.42`, which is not a valid assembly version and would fail the build. Setting
`InformationalVersion` directly takes any string, produces the same `version+sha` shape, and is the
only stamp anything reads.

**`ENV` rather than a re-declared `ARG`.** The `publish` stage is `FROM build`, and Docker does not
inherit `ARG` across stages. Promoting the composed value to `ENV` in `build` means both stages see
the same string with no second declaration to keep in sync.

## Consumers

n3oltd/backend reads it through `IReleaseInfoAccessor`, which splits the informational version on
`+` into `buildVersion` and `commit`, serves both from `/releaseinfo/v1.0`, and sources Sentry's
`opt.Release` from the build version so it matches the release the pipeline registers. **Merge this
first** — until it lands, that accessor reports `1.0.0` for every backend.

The build-args are passed to every image the workflow builds, not only .NET ones. Dockerfiles that
do not declare them ignore them with a warning.

## Noticed, not changed

The `publish` stage also uses `${CONFIGURATION}`, which is declared as an `ARG` in `build` and never
promoted to `ENV` — so by the same inheritance rule it is empty there. Worth a look, but it predates
this change and is not something I can verify without a build.

## Test plan

- [x] Confirmed `n3o-image-tags` emits `${CHANNEL:+${CHANNEL}-}${CALVER}.${RUN_NUMBER}`, so the
      channel case rules out `-p:Version`
- [x] Confirmed the `build` stage's `ARG CONFIGURATION` is not visible in `publish`, which is why
      the new value is promoted to `ENV`
- [x] Confirmed no other build-arg in this workflow carries a version for .NET images — the two
      version-shaped ones (`REACT_APP_SENTRY_RELEASE`, `VITE_SENTRY_RELEASE`) are frontend-only
- [ ] Reviewer: after merge, build one backend image and confirm the entry-point DLL reports
      `<calver>+<sha>` rather than `1.0.0`
