### PR TITLE
Serve release info from the n3o-node variants

### DIFF
--- a/docker/n3o-node
+++ b/docker/n3o-node
@@ -9,6 +9,8 @@
 #   PORT             port the final image listens on (default 8080)
 #   BASE_PATH        public path the static site is served under
 #   ENV_PREFIX       env vars with this prefix reach the browser as window.__APP_ENV__
+#   BUILD_VERSION    build number reported by releaseinfo/v1.0
+#   COMMIT_SHA       built commit reported by releaseinfo/v1.0
 
 ARG VARIANT=static
 
@@ -61,6 +63,12 @@ RUN chmod +x /usr/local/bin/run-build
 ENV PACKAGE=${PACKAGE} BUILD_SCRIPT=${BUILD_SCRIPT}
 RUN --mount=type=secret,id=github_token,required=true install-deps
 RUN run-build
+ARG OUTPUT_DIR
+ARG BUILD_VERSION
+ARG COMMIT_SHA
+RUN mkdir -p "${OUTPUT_DIR}/releaseinfo" && \
+    node -e "process.stdout.write(JSON.stringify({releaseVersion:null,buildVersion:process.env.BUILD_VERSION||null,commit:process.env.COMMIT_SHA||null}))" \
+    > "${OUTPUT_DIR}/releaseinfo/v1.0"
 
 ########################
 ### sourcemaps
@@ -81,6 +89,9 @@ ARG ENV_PREFIX=VITE_
 ARG PORT=8080
 ENV APP_BASE_PATH=${BASE_PATH}
 ENV APP_ENV_PREFIX=${ENV_PREFIX}
+ARG BUILD_VERSION
+ARG COMMIT_SHA
+ENV BUILD_VERSION=${BUILD_VERSION} COMMIT_SHA=${COMMIT_SHA}
 COPY --from=build /repo/${OUTPUT_DIR} /srv${BASE_PATH}
 # The build manifest is a version-pinned dependency inventory, never content to serve.
 RUN rm -rf /srv${BASE_PATH}.vite
@@ -99,6 +110,8 @@ jq -Rs --argjson cfg "$cfg" --arg baseHref "$base_href" -r \
        "<script id=\"__app_env_script__\">window.__APP_ENV__=" + ($cfg | tojson) + "</script>")
    | gsub("__APP_BASE__"; $baseHref)' \
   < "${dir}index.html.tmpl" > "${dir}index.html"
+mkdir -p "${dir}releaseinfo"
+jq -nc '{releaseVersion: env.RELEASE_VERSION, buildVersion: env.BUILD_VERSION, commit: env.COMMIT_SHA}' > "${dir}releaseinfo/v1.0"
 exec "$@"
 ENTRY
 RUN chmod +x /usr/local/bin/inject-app-env
@@ -119,6 +132,12 @@ COPY <<CADDY /etc/caddy/Caddyfile
 		file_server
 	}
 
+	handle ${BASE_PATH}releaseinfo/v1.0 {
+		header Content-Type application/json
+		header Cache-Control "no-store"
+		file_server
+	}
+
 	handle {
 		header Cache-Control "no-store"
 		try_files {path} ${BASE_PATH}index.html
@@ -135,6 +154,9 @@ RUN cd "${PACKAGE}" && npm prune --omit=dev
 FROM node:24-slim AS variant-node
 ARG PORT=8080
 ENV NODE_ENV=production PORT=${PORT}
+ARG BUILD_VERSION
+ARG COMMIT_SHA
+ENV BUILD_VERSION=${BUILD_VERSION} COMMIT_SHA=${COMMIT_SHA}
 WORKDIR /app
 ARG PACKAGE
 ARG START_ENTRY
@@ -150,6 +172,9 @@ CMD ["sh", "-c", "exec node ${START_ENTRY}"]
 FROM node:24-slim AS variant-next
 ARG PORT=8080
 ENV NODE_ENV=production PORT=${PORT} HOSTNAME=0.0.0.0
+ARG BUILD_VERSION
+ARG COMMIT_SHA
+ENV BUILD_VERSION=${BUILD_VERSION} COMMIT_SHA=${COMMIT_SHA}
 WORKDIR /app
 ARG OUTPUT_DIR
 COPY --from=build --chown=node:node /repo/${OUTPUT_DIR}/standalone ./


### PR DESCRIPTION
no-work-issue

Backends report what they are running at `releaseinfo/v1.0` — `{releaseVersion, buildVersion, commit}` — and the web apps built from this image now do the same. The shared build workflow already passes `BUILD_VERSION` and `COMMIT_SHA` as build args; the build stage bakes them into a `releaseinfo/v1.0` JSON file in the built output (`releaseVersion` null, since that fact does not exist until release), so every file-serving variant ships a version document that can only describe the files it travelled with.

The static variant upgrades the document at container boot: the entrypoint that already injects environment config into `index.html` rewrites the file with `RELEASE_VERSION` merged in — the App Service setting stamped by the release, which rides the same config update as the image and so cannot skew against it — and the Caddyfile serves it as JSON, uncached. The next and node variants expose the baked pair as environment for the server to compose the same payload; oauth serves the build-baked file as-is (its distroless runtime has no boot step).

Validated with the estate Caddy binary: the rendered config adapts cleanly with no TLS policy change and the route typed as JSON; both write commands verified to emit the exact payload including nulls for unset values.

## Test plan

- [x] `caddy adapt` on the rendered static-variant Caddyfile: clean, plain listener, route present with `application/json`
- [x] Build-stage and boot-time write commands produce the payload byte-shape, nulls included

🤖 Generated with [Claude Code](https://claude.com/claude-code)