### PR TITLE
Bake the build facts into the react image for release info

### DIFF
--- a/docker/n3o-react
+++ b/docker/n3o-react
@@ -49,6 +49,10 @@ FROM node:latest AS final
 
 WORKDIR /app
 
+ARG BUILD_VERSION
+ARG COMMIT_SHA
+ENV BUILD_VERSION=${BUILD_VERSION} COMMIT_SHA=${COMMIT_SHA}
+
 RUN npm install express@latest
 
 COPY --from=builder /app/build ./build


### PR DESCRIPTION
no-work-issue

The react image's final stage runs the consuming repository's express server, which composes `releaseinfo/v1.0` from its environment — the same env-composed form the next variant and the backends use. The shared build workflow already passes `BUILD_VERSION` and `COMMIT_SHA`; the final stage now bakes them as environment so the server can serve build facts that can only describe the image they shipped in. `RELEASE_VERSION` arrives from the app settings the release stamps.

## Test plan

- [x] Args ride into the final stage as env; no other stage changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)