### PR TITLE
Add a shared Renovate workflow

### DIFF
--- a/.github/workflows/n3o-renovate.yml
+++ b/.github/workflows/n3o-renovate.yml
@@ -1,10 +1,6 @@
-# Runs Renovate over the calling repository. What it updates is that repository's own
-# renovate.json; this workflow only supplies the runner and the credentials.
-#
-# The npm host rule is why this exists as a shared workflow rather than a copy per repository:
-# a private registry needs a token in two places, once for Renovate's own metadata lookups and
-# again for the package manager it shells out to when it rebuilds a lockfile. Repositories with
-# no private scope are unaffected by it.
+# A private registry needs the token twice: once for Renovate's metadata lookups, and again for
+# the package manager it shells out to when rebuilding a lockfile. Dropping either host rule
+# gives a run that resolves versions and then cannot install them.
 name: n3o renovate
 
 on:

--- a/.github/workflows/n3o-renovate.yml
+++ b/.github/workflows/n3o-renovate.yml
@@ -1,0 +1,51 @@
+# Runs Renovate over the calling repository. What it updates is that repository's own
+# renovate.json; this workflow only supplies the runner and the credentials.
+#
+# The npm host rule is why this exists as a shared workflow rather than a copy per repository:
+# a private registry needs a token in two places, once for Renovate's own metadata lookups and
+# again for the package manager it shells out to when it rebuilds a lockfile. Repositories with
+# no private scope are unaffected by it.
+name: n3o renovate
+
+on:
+  workflow_call:
+    inputs:
+      mode:
+        description: "runner mode: wait (self-hosted, free, queue) or fast (GitHub-hosted, immediate, billable)."
+        type: string
+        required: false
+        default: wait
+      log-level:
+        description: Renovate log level.
+        type: string
+        required: false
+        default: info
+    secrets:
+      token:
+        description: Classic PAT with repo and package read. App tokens are refused by the package registries.
+        required: true
+
+concurrency:
+  group: renovate-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  pick:
+    uses: n3oltd/actions/.github/workflows/n3o-pick-runner.yml@main
+    with:
+      mode: ${{ inputs.mode }}
+
+  renovate:
+    needs: pick
+    runs-on: ${{ needs.pick.outputs.runs-on }}
+    steps:
+      - uses: renovatebot/github-action@v46.2.0
+        with:
+          token: ${{ secrets.token }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_HOST_RULES: >-
+            [{"matchHost":"npm.pkg.github.com","hostType":"npm","token":"${{ secrets.token }}"},
+             {"matchHost":"nuget.pkg.github.com","hostType":"nuget","token":"${{ secrets.token }}"}]
+          LOG_LEVEL: ${{ inputs.log-level }}


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Renovate becomes the one dependency bot across the estate, replacing Dependabot everywhere. That
means five repositories need the same runner choice and the same registry credentials, so this puts
them in one shared workflow instead of five copies. A caller supplies the token; its own
`renovate.json` decides what gets updated.

The host rules are the reason this is shared rather than copied. A private registry needs the token
in **two** places: once for Renovate's own metadata lookups, and again for the package manager it
shells out to when it rebuilds a lockfile. With only the first, a run resolves versions correctly and
then fails to install them — which is exactly what a dry-run against `n3oltd/frontend` did before the
rule was added, with `ERR_PNPM_FETCH_401` and a failed lockfile check. Both the npm and NuGet
GitHub Packages hosts are covered, and a repository with no private scope is unaffected by either.

Runner selection reuses `n3o-pick-runner.yml`, so routine runs queue free on the self-hosted fleet
and a caller can pass `mode: fast` when it needs an immediate start.

## Test plan

- [x] Parses as valid YAML — two jobs, `mode` and `log-level` inputs, `token` secret
- [x] Verified against a full Renovate dry-run on `n3oltd/frontend`: with these host rules the run
      resolves `@n3oltd/*` from `npm.pkg.github.com`, resolves public packages from
      `registry.npmjs.org`, rebuilds the pnpm lockfile with zero 401s, and reaches
      `Would commit files to branch renovate/...`
- [x] Confirmed the same dry-run without host rules fails with `ERR_PNPM_FETCH_401` and
      `Lockfile failed supply-chain policy check`, so the rule is load-bearing rather than defensive
- [ ] First real run — observable once a calling repository merges its workflow
